### PR TITLE
Minors changes to support HP Office Jet 4680j

### DIFF
--- a/classes/Api.js
+++ b/classes/Api.js
@@ -73,7 +73,7 @@ module.exports = function () {
             brightness: req.brightness,
             contrast: req.contrast,
             outputFilepath: Config.PreviewDirectory + 'preview.tif',
-            resolution: 50
+            resolution: Config.PreviewResolution
         });
 
         var scanner = new Scanimage();

--- a/classes/Config.js
+++ b/classes/Config.js
@@ -9,5 +9,7 @@ module.exports = {
 	OutputDirectory: './data/output/',
 	PreviewDirectory: './data/preview/',
 	MaximumScanWidthInMm: 215,
-	MaximumScanHeightInMm: 297
+	MaximumScanHeightInMm: 297,
+	PreviewResolution: 100,
+	SupportsDepth: false;
 };

--- a/classes/Scanimage.js
+++ b/classes/Scanimage.js
@@ -15,7 +15,10 @@ module.exports = function () {
 	var commandLine = function (scanRequest) {
 		var cmd = Config.Scanimage;
 		cmd += ' --mode ' + scanRequest.mode;
-		cmd += ' --depth ' + scanRequest.depth;
+		
+		if (Config.SupportsDepth) {
+		  cmd += ' --depth ' + scanRequest.depth;
+		}
 		cmd += ' --resolution ' + scanRequest.resolution;
 		cmd += ' -l ' + scanRequest.left;
 		cmd += ' -t ' + scanRequest.top;


### PR DESCRIPTION
I ran into some minor issue when running the app using a HP Office Jet 4680j. The device does not support the depth option and the min resolution it supports is 100.