### PR TITLE
Make "depth" an optional request parameter

### DIFF
--- a/classes/ScanRequest.js
+++ b/classes/ScanRequest.js
@@ -42,6 +42,10 @@ var ScanRequest = function (def) {
 			errors.push('Invalid contrast: ' + _this.contrast);
 		}
 
+		if ('depth' in _this && !Number.isInteger(_this.depth)) {
+			errors.push('Invalid depth: ' + _this.depth);
+		}
+
 		if (_this.top + _this.height > Config.MaximumScanHeightInMm) {
 			errors.push('Top + height exceed maximum dimensions');
 		}
@@ -60,7 +64,6 @@ ScanRequest.default = {
 	width: Config.MaximumScanWidthInMm,
 	height: Config.MaximumScanHeightInMm,
 	mode: "Color",
-	depth: 8,
 	resolution: 200,
 	format: "tiff",
 	outputFilepath: "",

--- a/classes/Scanimage.js
+++ b/classes/Scanimage.js
@@ -23,7 +23,7 @@ module.exports = function () {
 		var cmd = Config.Scanimage;
 		cmd += ' --mode "' + scanRequest.mode + '"';
 		
-		if (device.isFeatureSupported('--depth')) {
+		if (device.isFeatureSupported('--depth') && 'depth' in scanRequest) {
 			cmd += ' --depth ' + scanRequest.depth;
 		}
 


### PR DESCRIPTION
While using lineart mode, scanimage errors out with the following message :
```
$ scanimage --mode Lineart --format tiff --depth 8 --resolution 600 > foo.tif
scanimage: attempted to set inactive option depth
```
Skipping the `--depth` parameter makes the scanning work as expected, and doesn't break any of the other scanning modes.

This is my first time writing any JavaScript, so please bear with me...