### PR TITLE
Allow disabling dynamic lineart mode

### DIFF
--- a/classes/Api.js
+++ b/classes/Api.js
@@ -63,9 +63,11 @@ module.exports = function () {
 
     _this.preview = function (req) {
         var scanRequest = new ScanRequest({
+            device: req.device,
             mode: req.mode,
             brightness: req.brightness,
             contrast: req.contrast,
+            disableDynamicLineart: req.disableDynamicLineart,
             outputFilepath: Config.PreviewDirectory + 'preview.tif',
             resolution: Config.PreviewResolution
         });

--- a/classes/Device.js
+++ b/classes/Device.js
@@ -27,7 +27,7 @@ module.exports = function () {
             'features': {}
         };
         
-        var pattern = /\s+([-]{1,2}[-a-zA-Z0-9]+) (.*) \[(.*)\]\n/g;
+        var pattern = /\s+([-]{1,2}[-a-zA-Z0-9]+) ?(.*) \[(.*)\]\n/g;
         var match;
         while ((match = pattern.exec(response)) !== null) {
             device.features[match[1]] = {

--- a/classes/ScanRequest.js
+++ b/classes/ScanRequest.js
@@ -12,7 +12,7 @@ var ScanRequest = function (def) {
 		_this.outputFilepath = Config.OutputDirectory + 'scan_' + dateString + '.' + _this.convertFormat;
 	}
 
-	_this.validate = function () {
+	_this.validate = function (device) {
 		var errors = [];
 
 		if (_this.mode === undefined) {
@@ -55,6 +55,10 @@ var ScanRequest = function (def) {
 			errors.push('Invalid format type');
 		}
 
+		if (_this.disableDynamicLineart && !device.isFeatureSupported('--disable-dynamic-lineart')) {
+			errors.push('disableDynamicLineart set to true, but unsupported by device');
+		}
+
 		return errors;
 	};
 };
@@ -70,7 +74,8 @@ ScanRequest.default = {
 	outputFilepath: "",
 	brightness: 0,
 	contrast: 0,
-	convertFormat: 'tif'
+	convertFormat: 'tif',
+	disableDynamicLineart: false
 };
 
 module.exports = ScanRequest;

--- a/index.html
+++ b/index.html
@@ -69,6 +69,11 @@
                         </select>
                     </div>
 
+                    <div class="form-check" id="formGroupDisableDynamicLineart">
+                        <label for="disableDynamicLineart" class="form-check-label">Disable dynamic lineart</label>
+                        <input id="disableDynamicLineart" type="checkbox" class="form-check-input" />
+                    </div>
+
                     <label for="brightness">Brightness</label>
                     <input id="brightness" type="text" class="form-control" />
                     <div id="brightness_slider" class="slider"></div>

--- a/src/client.css
+++ b/src/client.css
@@ -61,6 +61,10 @@ label, th {
     color: #0E5EA0;
 }
 
+.form-check-label {
+    font-size: smaller;
+}
+
 h1 {
     font-size: 4em;
     font-weight: 100;


### PR DESCRIPTION
My CanoScan LiDE 200 scanner, based on the genesys backed, has an option to "disable dynamic lineart" and revert back to the hardware implementation. Making lineart scans *without* that option results in much less usable scans (compare : [with](https://imgur.com/9iktWEW) and [without](https://imgur.com/XeLu1Sw)), and as such I'd like it to be always enabled when making lineart scans - sadly, I don't think there is an option like this in SANE itself.
Perhaps device.conf isn't really a good place for this, but I have to admit I can't see this option being set anywhere else.