### PR TITLE
Don't replace ScanRequest.outputFilepath if one was already specified

### DIFF
--- a/classes/ScanRequest.js
+++ b/classes/ScanRequest.js
@@ -7,9 +7,10 @@ var ScanRequest = function (def) {
 	_this = this;
 
 	System.extend(_this, ScanRequest.default, def);
-
-	var dateString = dateFormat(new Date(), 'yyyy-mm-dd HH.MM.ss');
-	_this.outputFilepath = Config.OutputDirectory + 'scan_' + dateString + '.' + _this.convertFormat;
+	if (!_this.outputFilepath) {
+		var dateString = dateFormat(new Date(), 'yyyy-mm-dd HH.MM.ss');
+		_this.outputFilepath = Config.OutputDirectory + 'scan_' + dateString + '.' + _this.convertFormat;
+	}
 
 	_this.validate = function () {
 		var errors = [];


### PR DESCRIPTION
Fixes #16 . The file with the scan's preview simply never made it to `Config.PreviewDirectory + 'preview.tif'`, since it was unconditionally set to the "normal scan" variant by `ScanRequest()`.