### PR TITLE
Added capability to select a specific device via config parameter

### DIFF
--- a/classes/Config.js
+++ b/classes/Config.js
@@ -2,6 +2,7 @@ module.exports = {
 	Port: 8080,
 	IsTrace: true,
 	TraceLineEnding: '',
+	DeviceName: null,
 	Scanimage: '/usr/bin/scanimage',
 	Convert: '/usr/bin/convert',
 	IgnoreStdError: '2>/dev/null',

--- a/classes/Device.js
+++ b/classes/Device.js
@@ -47,7 +47,11 @@ module.exports = function () {
 
     /// Executes scanimageA and returns a promise of parsed results
     var scanimageA = function () {
-        var cmd = Config.Scanimage + ' -A';
+        var cmd = Config.Scanimage;
+        if(Config.DeviceName){
+            cmd += ' -d "'+Config.DeviceName+'"';
+        }
+        cmd += ' -A';
 
         return System.execute(cmd)
             .then(function (reply) {

--- a/classes/Scanimage.js
+++ b/classes/Scanimage.js
@@ -15,6 +15,9 @@ module.exports = function () {
 
 	var commandLine = function (scanRequest, device) {
 		var cmd = Config.Scanimage;
+		if(device.data.name) {
+			cmd += ' -d "' + device.data.name + '"'
+		}
 		cmd += ' --mode "' + scanRequest.mode + '"';
 		
 		if (device.isFeatureSupported('--depth') && 'depth' in scanRequest) {


### PR DESCRIPTION
In my case i had to preselect a specific device from my pixma 850 in order to avoid network timeouts and go straight to the local usb device. 

```
device `pixma:MX850_192.168*****' is a CANON Canon PIXMA MX850 multi-function peripheral
device `pixma:04A9********' is a CANON Canon PIXMA MX850 multi-function peripheral
```

Therefore i added an optional config parameter that may be used to define a devicename that will be applied to the scanimage -A command. Furthermore the determined device name from Device.js is going to be applied to scanimage calls created by ScanRequest anyway if present.