### PR TITLE
Set colour/mode to device default on reset

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -110,11 +110,10 @@ $(document).ready(function () {
 
         reset: function () {
             var defaults = this.model.defaults();
+            defaults.mode = this.device.attributes.features['--mode'].default; // Set colour/mode to device default
             this.model.set(defaults);
-            this.model.attributes.mode = this.device.attributes.features['--mode'].default; // Set colour/mode to device default
             this.model.save();
             jcrop.draw();
-            this.render(); // We need this to update the combo box
         },
 
         // For debug only - but useful for when things

--- a/src/client.js
+++ b/src/client.js
@@ -111,8 +111,10 @@ $(document).ready(function () {
         reset: function () {
             var defaults = this.model.defaults();
             this.model.set(defaults);
+            this.model.attributes.mode = this.device.attributes.features['--mode'].default; // Set colour/mode to device default
             this.model.save();
             jcrop.draw();
+            this.render(); // We need this to update the combo box
         },
 
         // For debug only - but useful for when things


### PR DESCRIPTION
Before it simply cleared the selected item in the combo box which prevented preview from working until a new item was selected.

This fixes #34

I'm unsure about ``this.render();``. It works, but there might be a better solution.