### PR TITLE
Use Google's material-design-icons as an alternative to glyphicons

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <script src="assets/js/app.js" type="text/javascript"></script>
     <link rel="stylesheet" href="assets/css/app.css" type="text/css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat" type="text/css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 </head>
 
 <script type="text/template" id="file-row">
@@ -97,9 +98,9 @@
             <div class="row">
                 <div class="col text-right">
                     <div class="btn-group" role="group" aria-label="...">
-                        <button id="reset" type="button" class="btn btn-lg">reset <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span></button>
-                        <button id="preview" type="button" class="btn btn-lg">preview <span class="glyphicon glyphicon-search" aria-hidden="true"></span></button>
-                        <button id="scan" type="button" class="btn btn-lg">scan <span class="glyphicon glyphicon-camera" aria-hidden="true"></span></button>
+                        <button id="reset" type="button" class="btn btn-lg">reset <span class="material-icons" aria-hidden="true">autorenew</span></button>
+                        <button id="preview" type="button" class="btn btn-lg">preview <span class="material-icons" aria-hidden="true">search</span></button>
+                        <button id="scan" type="button" class="btn btn-lg">scan <span class="material-icons" aria-hidden="true">photo_camera</span></button>
                     </div>
                 </div>
             </div>

--- a/src/client.css
+++ b/src/client.css
@@ -89,3 +89,8 @@ h1 {
 .toast-error {
     background-color: red
 }
+
+/* center the icons vertically */
+.material-icons {
+    vertical-align: middle;
+}


### PR DESCRIPTION
Glyphicons have been dropped from Bootstrap in version 4 (see https://getbootstrap.com/docs/4.0/migration/#components).

Hence, the icons for the "reset", "preview" and "scan"-buttons don't work since 29dcab70d7cfaa2707f1dcb34173f3061d0a0914.

I tried to find some alternatives for them in Google's material icons (see https://material.io/resources/icons). Tell me if you aren't happy with them. I'm not sure about the size, maybe a little bit bigger would be good.