### PR TITLE
Revert "Hide inactive features/options from UI and automatically set slider limits"

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,14 @@
                     <div class="form-group">
                         <label for="resolution">Resolution</label>
                         <select id="resolution" class="form-control">
+                            <option value="50">50 dpi</option>
+                            <option value="75">75 dpi</option>
+                            <option value="100">100 dpi</option>
+                            <option value="150">150 dpi</option>
+                            <option value="200">200 dpi</option>
+                            <option value="300">300 dpi</option>
+                            <option value="600">600 dpi</option>
+                            <option value="1200">1200 dpi</option>
                         </select>
                     </div>
 
@@ -67,17 +75,13 @@
                         </select>
                     </div>
 
-                    <div class="form-group" id="brightness_option" style="display: none">
-                        <label for="brightness">Brightness</label>
-                        <input id="brightness" type="text" class="form-control" />
-                        <div id="brightness_slider" class="slider"></div>
-                    </div>
+                    <label for="brightness">Brightness</label>
+                    <input id="brightness" type="text" class="form-control" />
+                    <div id="brightness_slider" class="slider"></div>
 
-                    <div class="form-group" id="contrast_option" style="display: none">
-                        <label for="Contrast">Contrast</label>
-                        <input id="contrast" type="text" class="form-control" />
-                        <div id="contrast_slider" class="slider"></div>
-                    </div>
+                    <label for="Contrast">Contrast</label>
+                    <input id="contrast" type="text" class="form-control" />
+                    <div id="contrast_slider" class="slider"></div>
 
                     <div class="form-group">
                         <label for="convertFormat">Format</label>

--- a/src/client.js
+++ b/src/client.js
@@ -84,7 +84,6 @@ $(document).ready(function () {
         device: null,
         files: null,
         resizeTimer: null,
-        limits: null,
 
         el: $("#app"),
         tagName: 'div',
@@ -149,10 +148,8 @@ $(document).ready(function () {
                     var val = parseInt(field.value);
                     var $slider = $("#" + field.id + "_slider");
                     val = isNaN(val) ? $slider.slider("value") : val;
-                    if (this.limits && this.limits[field.id]) {
-                        if (val < this.limits[field.id].min) val = this.limits[field.id].min;
-                        if (val > this.limits[field.id].max) val = this.limits[field.id].max;
-                    }
+                    if (val < -100) val = -100;
+                    if (val > 100) val = 100;
                     field.value = val;
                     data[field.id] = val;
                     $slider.slider("value", val);
@@ -279,8 +276,6 @@ $(document).ready(function () {
             this.files = new FileCollection();
             this.listenTo(this.files, 'add', this.add);
             this.files.fetch();
-
-            this.limits = {};
         },
 
         diagnosticsSync: function (diagnostics) {
@@ -301,49 +296,9 @@ $(document).ready(function () {
                 $mode.append('<option>' + val + '</option>');
             });
 
-            if (device.attributes.features['--resolution']) {
-                var resolutionString = device.attributes.features['--resolution'].options;
-                if (resolutionString.endsWith('dpi')) { // remove trailing "dpi" if present
-                    resolutionString = resolutionString.substr(0, resolutionString.length - 3);
-                }
-
-                var resolutions = resolutionString.split('|');
-                var $resolution = $('#resolution');
-                _.each(resolutions, function (val) {
-                    $resolution.append('<option value="' + val + '">' + val + ' dpi</option>');
-                });
-            } else {
-                toastr.error("no resolutions available for scanner");
-            }
-
             if (this.model.attributes.mode === null) {
                 this.model.attributes.mode = device.attributes.features['--mode'].default;
             }
-
-            _.each(device.attributes.features, function(val, key) {
-                var id = key.substr(2, key.length - 2); // remove leading "--" of which we just assume that it's present
-
-                var $e = this.$('#' + id + '_option');
-                if ($e) {
-                    $e.toggle(true);
-                }
-
-                if (id === 'contrast' || id === 'brightness') {
-                    var bounds = val.options.split('..');
-
-                    // save limits
-                    page.limits[id] = {min: bounds[0], max: bounds[1]};
-
-                    // adjust current values to limit
-                    if (page.model.attributes[id] < bounds[0])
-                        page.model.attributes[id] = bounds[0];
-                    if (page.model.attributes[id] > bounds[1])
-                        page.model.attributes[id] = bounds[1];
-
-                    $e = this.$('#' + id + '_slider');
-                    $e.slider({min: bounds[0], max: bounds[1]});
-                }
-            });
 
             $('#version').text(device.attributes.version);
             


### PR DESCRIPTION
Reverts sbs20/scanservjs#40

I have to revert this unfortunately as it breaks everything on my scanner. It seems that what goes into Device feature options can vary a lot between scanners.

For instance, mine shows:

```json
        "--resolution": {
            "default": "50",
            "options": "50..1200dpi"
        },
```

Which shows a range.

It also breaks the sliders for me. I need to have a think about how we do this.