### PR TITLE
implemented config-option to clear preview on scan

### DIFF
--- a/server/config/config.local.js
+++ b/server/config/config.local.js
@@ -12,6 +12,7 @@ module.exports = {
     // config.convert = '/usr/bin/convert';
     // config.tesseract = '/usr/bin/tesseract';
     // config.previewResolution = 100;
+    // config.clearPreviewOnScan = false;
 
     /* When all scans are complete, the filenames are all piped into stdin of the
     first pipeline command. It would be nicer to pipe the binary output of scanimage

--- a/server/src/api.js
+++ b/server/src/api.js
@@ -98,6 +98,12 @@ class Api {
    * @returns {ScanResponse}
    */
   static async scan(req) {
+    if (Config.clearPreviewOnScan) {
+      const preview = new FileInfo(`${Config.previewDirectory}preview.tif`);
+      if (preview.exists()) {
+        preview.delete();
+      }
+    }
     return await ScanController.run(req);
   }
 

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -17,6 +17,7 @@ class Config {
       port: 8080,
       devices: [],
       ocrLanguage: 'eng',
+      clearPreviewOnScan: false,
       log: {
         level: 'DEBUG',
         prefix: {


### PR DESCRIPTION
Hi,

the intention of this PR is to give the administrator control over the preview image.
Currently the preview cannot be delete by WebUI and is not removed by any automated process.
This results in the situation that even after successful scanning everyone can see what was scanned as preview last time.

With this PR the administrator of scanservjs can set `config.clearPreviewOnScan = true;` in `config/config.local.js`.
This option then activates that the preview image will be removed when the user scans the image to be stored.

If there are any questions or hints on improving this PR let me known.


Regards,
Andrwe

Signed-off-by: Andrwe Lord Weber <github@andrwe.org>