### PR TITLE
Translated Czech locale name

### DIFF
--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -154,7 +154,7 @@
   },
 
   "locales": {
-    "cs": "Czech",
+    "cs": "Čeština",
     "de": "Deutsche",
     "en": "English",
     "es": "Español",


### PR DESCRIPTION
I hope I understand, if I'm not right, ignore this, please. Other languages have its locale name in national form (divided from used language) - for ex. "Deutsche", not "German". In this case your record for Czech language is wrong. We use the name "Čeština" for our language :D.