### PR TITLE
Device discovery gracefulness #285

### DIFF
--- a/packages/server/src/devices.js
+++ b/packages/server/src/devices.js
@@ -63,17 +63,26 @@ class Devices {
       let deviceIds = Config.devices;
       log.debug('Config.devices: ', deviceIds);
       if (Config.devicesFind) {
-        const data = await Process.execute(Scanimage.devices());
-        log.debug('Device list: ', data);
-        const localDevices = Devices._parseDevices(data);
-        deviceIds = deviceIds.concat(localDevices);
+        try {
+          const { stdout } = await Process.execute(Scanimage.devices());
+          log.debug('Device list: ', stdout);
+          const localDevices = Devices._parseDevices(stdout);
+          deviceIds = deviceIds.concat(localDevices);
+        } catch (e) {
+          log.error(e);
+        }
       }
 
       devices = [];
       for (let deviceId of deviceIds) {
-        const data = await Process.execute(Scanimage.features(deviceId));
-        log.debug('Device features: ', data);
-        devices.push(Device.from(data));
+        log.debug('Retrieving device features of', deviceId);
+        try {
+          const { stdout } = await Process.execute(Scanimage.features(deviceId));
+          log.debug('Device features: ', stdout);
+          devices.push(Device.from(stdout));
+        } catch (e) {
+          log.error(e);
+        }
       }
       file.save(JSON.stringify(devices, null, 2));
     }

--- a/packages/server/src/process.js
+++ b/packages/server/src/process.js
@@ -10,8 +10,7 @@ const Process = {
    * @returns {Promise.<string>}
    */
   async execute(cmd) {
-    const { stdout } = await exec(cmd);
-    return stdout;
+    return await exec(cmd);
   },
 
   /**

--- a/packages/server/test/process.test.js
+++ b/packages/server/test/process.test.js
@@ -5,20 +5,20 @@ const Process = require('../src/process');
 
 describe('Process', () => {
   it('echo', async () => {
-    const result = await Process.execute(new CmdBuilder('echo').arg('hello world').build());
-    assert.strictEqual(result, 'hello world\n');
+    const { stdout } = await Process.execute(new CmdBuilder('echo').arg('hello world').build());
+    assert.strictEqual(stdout, 'hello world\n');
   });
 
   it('echo-security', async () => {
     let result = null;
     result = await Process.execute(new CmdBuilder('echo').arg('-n', 'hello" && ls -al;# world').build());
-    assert.strictEqual(result, 'hello" && ls -al;# world');
+    assert.strictEqual(result.stdout, 'hello" && ls -al;# world');
 
     result = await Process.execute(new CmdBuilder('echo').arg('-n', '`ls -al`').build());
-    assert.strictEqual(result, '`ls -al`');
+    assert.strictEqual(result.stdout, '`ls -al`');
 
     result = await Process.execute(new CmdBuilder('echo').arg('-n', '$(date)').build());
-    assert.strictEqual(result, '$(date)');
+    assert.strictEqual(result.stdout, '$(date)');
   });
 
   it('echo "1\\n2\\n3" | wc -l', async () => {


### PR DESCRIPTION
Here's a suggested fix. I tried hard to add a test case which asserts an error from `exit 1`, but didn't manage to make it work. :disappointed: 

Anyway, log output with the fix:
```
scanservjs | [2021-05-27T20:39:42.675Z] INFO (server): Started
scanservjs | [2021-05-27T20:39:48.486Z] DEBUG (Http): request:  { method: 'GET', path: '/context' }
scanservjs | [2021-05-27T20:39:48.489Z] DEBUG (Devices): devices.json does not exist. Reloading
scanservjs | [2021-05-27T20:39:48.489Z] DEBUG (Devices): Config.devices:  []
scanservjs | [2021-05-27T20:39:53.180Z] DEBUG (Devices): Device list:  device `brother4:net1;dev1' is a Brother ADS-2600W-Wired ADS-2600W
scanservjs | device `brother4:net1;dev0' is a Brother ADS-2600W-Wifi ADS-2600W
scanservjs | 
scanservjs | [2021-05-27T20:39:53.181Z] DEBUG (Devices): Retrieving device features of  brother4:net1;dev1
scanservjs | [2021-05-27T20:40:15.594Z] ERROR (Devices): Error: Command failed: /usr/bin/scanimage -d 'brother4:net1;dev1' -A
scanservjs | scanimage: open of device brother4:net1;dev1 failed: Invalid argument
scanservjs | 
scanservjs |     at ChildProcess.exithandler (child_process.js:319:12)
scanservjs |     at ChildProcess.emit (events.js:376:20)
scanservjs |     at maybeClose (internal/child_process.js:1055:16)
scanservjs |     at Process.ChildProcess._handle.onexit (internal/child_process.js:288:5) {
scanservjs |   killed: false,
scanservjs |   code: 1,
scanservjs |   signal: null,
scanservjs |   cmd: "/usr/bin/scanimage -d 'brother4:net1;dev1' -A",
scanservjs |   stdout: '',
scanservjs |   stderr: 'scanimage: open of device brother4:net1;dev1 failed: Invalid argument\n'
scanservjs | }
scanservjs | [2021-05-27T20:40:15.597Z] DEBUG (Devices): Retrieving device features of  brother4:net1;dev0
scanservjs | [2021-05-27T20:40:17.549Z] DEBUG (Devices): Device features:  
scanservjs | All options specific to device `brother4:net1;dev0':
scanservjs |   Mode:
scanservjs |     --mode Black & White|Gray[Error Diffusion]|True Gray|24bit Color|24bit Color[Fast] [24bit Color[Fast]]
scanservjs |         Select the scan mode
scanservjs |     --resolution 100|150|200|300|400|600|1200|2400|4800|9600dpi [200]
scanservjs |         Sets the resolution of the scanned image.
scanservjs |     --source Automatic Document Feeder(left aligned)|Automatic Document Feeder(left aligned,Duplex)|Automatic Document Feeder(centrally aligned)|Automatic Document Feeder(centrally aligned,Duplex) [Automatic Document Feeder(left aligned)]
scanservjs |         Selects the scan source (such as a document-feeder).
scanservjs |     --brightness -50..50% (in steps of 1) [inactive]
scanservjs |         Controls the brightness of the acquired image.
scanservjs |     --contrast -50..50% (in steps of 1) [inactive]
scanservjs |         Controls the contrast of the acquired image.
scanservjs |   Geometry:
scanservjs |     -l 0..211.9mm (in steps of 0.0999908) [0]
scanservjs |         Top-left x position of scan area.
scanservjs |     -t 0..812.8mm (in steps of 0.0999908) [0]
scanservjs |         Top-left y position of scan area.
scanservjs |     -x 0..211.9mm (in steps of 0.0999908) [211.881]
scanservjs |         Width of scan-area.
scanservjs |     -y 0..812.8mm (in steps of 0.0999908) [415.962]
scanservjs |         Height of scan-area.
scanservjs | 
scanservjs | 
scanservjs | [2021-05-27T20:40:17.665Z] DEBUG (Http): request:  { method: 'POST', path: '/preview' }
scanservjs | [2021-05-27T20:40:17.668Z] DEBUG (Process): convert - -resize 868x3329! jpg:-,  <Buffer ff d8 ff e0 00 10 4a 46 49 46 00 01 01 01 00 b4 00 b4 00 00 ff e1 79 9c 45 78 69 66 00 00 49 49 2a 00 08 00 00 00 0d 00 0f 01 02 00 0a 00 00 00 aa 00 ... 265267 more bytes> , {"encoding":"binary","shell":true,"maxBuffer":16384,"ignoreErrors":false}
```