### PR TITLE
Updated Czech translation

### DIFF
--- a/packages/client/src/locales/cs.json
+++ b/packages/client/src/locales/cs.json
@@ -44,12 +44,12 @@
     "date": "Datum",
     "size": "Velikost",
     "message:deleted": "Odstraněno",
-    "message:renamed": "File renamed",
-    "button:delete-selected": "Delete Selected",
-    "dialog:rename": "Change file name",
-    "dialog:rename-cancel": "Cancel",
-    "dialog:rename-save": "Save",
-    "actions": "Actions"
+    "message:renamed": "Soubor byl přejmenován",
+    "button:delete-selected": "Odstranit vybrané",
+    "dialog:rename": "Změnit název souboru",
+    "dialog:rename-cancel": "Zrušit",
+    "dialog:rename-save": "Uložit",
+    "actions": "Akce"
   },
 
   "navigation": {
@@ -120,8 +120,8 @@
     "ledger": "Ledger",
     "junior-legal": "Junior legal",
     "half-letter": "Half letter",
-    "portrait": "Portrait",
-    "landscape": "Landscape"
+    "portrait": "Na výšku",
+    "landscape": "Na šířku"
   },
 
   "scan": {


### PR DESCRIPTION
I've updated translation of file renaming messages and some items in paper sizes section. There is one thing - we aren't use US papers like "Letter", "Legat" etc. at all. So, we haven't any Czech words for these items. I can only translate "Half letter" to "Poloviční letter", which is bad translation - "Half letter" is the name of the paper size and it shouldn't be translated in a half way. So, it's not my bad there is missing some translations. They are actualy not missing :D.