### PR TITLE
Turning document and more explicit title for preview heading in Czech translation

### DIFF
--- a/packages/client/src/locales/cs.json
+++ b/packages/client/src/locales/cs.json
@@ -151,7 +151,7 @@
     "message:no-devices": "Nebyla nalezena žádná zařízení",
     "message:deleted-preview": "Náhled byl odstraněn",
     "message:turn-documents": "Obraťte skenované dokumenty",
-    "message:preview-of-page": "Náhled strany"
+    "message:preview-of-page": "Náhled strany č."
   },
 
   "settings": {

--- a/packages/client/src/locales/cs.json
+++ b/packages/client/src/locales/cs.json
@@ -150,7 +150,7 @@
     "message:loading-devices": "Načítání zařízení...",
     "message:no-devices": "Nebyla nalezena žádná zařízení",
     "message:deleted-preview": "Náhled byl odstraněn",
-    "message:turn-documents": "Obrátit dokumenty",
+    "message:turn-documents": "Obraťte skenované dokumenty",
     "message:preview-of-page": "Náhled strany"
   },
 


### PR DESCRIPTION
Fixed turning document message in Czech translation (see #365).

In Czech language we like the "no." ("č.") before the whole number.