### PR TITLE
Update preview image efficiently after full scan

### DIFF
--- a/packages/server/src/scan-controller.js
+++ b/packages/server/src/scan-controller.js
@@ -138,11 +138,11 @@ class ScanController {
       const left = Math.round(this.request.params.left * previewScale);
       const top = Math.round(this.request.params.top * previewScale);
       const width = Math.round(this.request.params.width * previewScale);
-      cmdBuilder.arg('-resize', width)
+      cmdBuilder.arg('-scale', width)
         .arg('-background', '#808080')
         .arg('-extent', `${previewWidth}x${previewHeight}-${left}-${top}`);
     } else {
-      cmdBuilder.arg('-resize', previewWidth);
+      cmdBuilder.arg('-scale', previewWidth);
     }
 
     cmdBuilder.arg(`'${Config.previewDirectory}/preview.tif'`);

--- a/packages/server/src/scan-controller.js
+++ b/packages/server/src/scan-controller.js
@@ -129,22 +129,23 @@ class ScanController {
    * @returns {Promise.<void>}
    */
   async updatePreview(filename) {
-    const dpmm = this.request.params.resolution / 25.4;
+    const previewWidth = 868;
     const device = this.context.getDevice(this.request.params.deviceId);
     const cmdBuilder = new CmdBuilder(Config.convert).arg(`'${Config.tempDirectory}/${filename}'`);
     if (device.geometry) {
-      const geometry = {
-        width: device.features['-x'].limits[1] * dpmm,
-        height: device.features['-y'].limits[1] * dpmm,
-        left: this.request.params.left * dpmm,
-        top: this.request.params.top * dpmm
-      };
-      cmdBuilder.arg('-background', '#808080')
-        .arg('-extent', `${geometry.width}x${geometry.height}-${geometry.left}-${geometry.top}`);
+      const previewScale = previewWidth / device.features['-x'].limits[1];
+      const previewHeight = Math.round(device.features['-y'].limits[1] * previewScale);
+      const left = Math.round(this.request.params.left * previewScale);
+      const top = Math.round(this.request.params.top * previewScale);
+      const width = Math.round(this.request.params.width * previewScale);
+      cmdBuilder.arg('-resize', width)
+        .arg('-background', '#808080')
+        .arg('-extent', `${previewWidth}x${previewHeight}-${left}-${top}`);
+    } else {
+      cmdBuilder.arg('-resize', previewWidth);
     }
 
-    cmdBuilder.arg('-resize', 868)
-      .arg(`'${Config.previewDirectory}/preview.tif'`);
+    cmdBuilder.arg(`'${Config.previewDirectory}/preview.tif'`);
 
     await Process.spawn(cmdBuilder.build());
   }


### PR DESCRIPTION
Resize the scanned image first, and then adjust its extents based on the scan area (when the device geometry is known). Also, change the resize operator from "-resize" to "-scale".

The resulting image will be the same without a noticeable change in image quality. However, these changes have been tested to reduce the processing time by more than an order of magnitude.