### PR TITLE
Updated docker file to add support for more OCR languages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,18 @@ RUN apt-get update \
     sane \
     sane-utils \
     tesseract-ocr \
+    tesseract-ocr-ces \
+    tesseract-ocr-deu \
+    tesseract-ocr-eng \
+    tesseract-ocr-spa \
+    tesseract-ocr-fra \
+    tesseract-ocr-ita \
+    tesseract-ocr-nld \
+    tesseract-ocr-pol \
+    tesseract-ocr-por \
+    tesseract-ocr-rus \
+    tesseract-ocr-tur \
+    tesseract-ocr-chi-sim \
     sane-airscan \
   && sed -i \
     's/policy domain="coder" rights="none" pattern="PDF"/policy domain="coder" rights="read | write" pattern="PDF"'/ \
@@ -60,7 +72,7 @@ ENV \
   # Override OCR language
   OCR_LANG=""
 
-# Copy entry point
+# Copy entry point
 COPY run.sh /run.sh
 RUN ["chmod", "+x", "/run.sh"]
 ENTRYPOINT [ "/run.sh" ]


### PR DESCRIPTION
As suggested in #435 , I've added the install commands for all languages supported by scanservjs.