### PR TITLE
Integration Plugin with Paperless integration

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -13,7 +13,10 @@ directory for files and then does something with them.
 
 ## paperless-ng
 
-[This discussion](https://github.com/sbs20/scanservjs/issues/351#issuecomment-913858423)
+Paperless integration can be added via the config file in `config/config.local.js`
+
+Separately and prior to the Paperless integration,
+[this discussion](https://github.com/sbs20/scanservjs/issues/351#issuecomment-913858423)
 about paperless-ng resulted in
 [scantopl](https://github.com/Celedhrim/scantopl)
 

--- a/packages/server/config/config.default.js
+++ b/packages/server/config/config.default.js
@@ -82,6 +82,27 @@ module.exports = {
      * Append to existing pipelines
      */
     // config.pipelines.push(myPipelines[0]);
+
+
+    /* Integration Plugins */
+
+    // Paperless Integration example
+    //
+    // Prevent accessing secrets from the UI
+    // config.plugin_secrets = {
+    //   paperless: {
+    //     token: 'xxxxxxxxxx'
+    //   }
+    // };
+
+    // config.plugins = {
+    //   paperless: {
+    //     hostname: 'paperless.mysite.com',
+    //     https: true,
+    //     always_send: false,  // whether to upload every scan automatically
+    //     show_upload_icon: true, // shows the "Send to Paperless" upload button on Files page
+    //   }
+    // };
   },
 
   /**

--- a/packages/server/src/api.js
+++ b/packages/server/src/api.js
@@ -3,6 +3,7 @@ const Config = require('./config');
 const Context = require('./context');
 const Devices = require('./devices');
 const FileInfo = require('./file-info');
+const IntegrationPlugin = require('./integration-plugins');
 const Filters = require('./filters');
 const Process = require('./process');
 const Request = require('./request');
@@ -24,6 +25,13 @@ class Api {
       .sort((f1, f2) => f2.lastModified - f1.lastModified);
     log.trace(JSON.stringify(files));
     return files;
+  }
+
+  static async integrationPluginList() {
+    log.trace('integrationPluginList()');
+    const plugins = IntegrationPlugin.list();
+    log.trace(JSON.stringify(plugins));
+    return plugins;
   }
 
   /**

--- a/packages/server/src/configure.js
+++ b/packages/server/src/configure.js
@@ -112,6 +112,17 @@ function configure(app, rootPath) {
     }
   });
 
+  app.get('/integration-plugins', async(req, res) => {
+    logRequest(req);
+    try {
+      res.send({
+        config: await Api.integrationPluginList()
+      });
+    } catch (error) {
+      sendError(res, 500, error);
+    }
+  });
+
   app.get('/files', async (req, res) => {
     logRequest(req);
     try {

--- a/packages/server/src/integration-plugins.js
+++ b/packages/server/src/integration-plugins.js
@@ -1,0 +1,8 @@
+const Config = require('./config');
+
+class IntegrationPlugin {
+  static list() {
+    return Config.plugins || {};
+  }
+}
+module.exports = IntegrationPlugin;

--- a/packages/server/src/integration-plugins/base.js
+++ b/packages/server/src/integration-plugins/base.js
@@ -1,0 +1,47 @@
+const Config = require('../config');
+
+// Base class for Integration Plugin functionality
+class BasePlugin {
+
+  constructor(pluginconfig, pluginsecret) {
+    this.pluginconfig = pluginconfig;
+    this.pluginsecret = pluginsecret;
+  }
+
+
+  /**
+   * @param {FileInfo} fileInfo
+   */
+  onScan(fileInfo) {}
+
+  static runOnScan(fileInfo) {
+    this.getRegisteredPlugins().forEach((pluginObj) => {
+      pluginObj.onScan(fileInfo);
+    });
+
+  }
+
+  static getPlugin(name) {
+    const PaperlessPlugin = require('./paperless');
+    if (name === 'paperless') {
+      return PaperlessPlugin;
+    }
+    throw new Error(`Unrecognized plugin ${name}`);
+  }
+
+  /**
+   * Gets all the plugin objects instantiated
+   */
+  static getRegisteredPlugins() {
+    let plugins = [];
+    for (const plugin in Config.plugins) {
+      const Plugin = BasePlugin.getPlugin(plugin);
+      const pluginconfig = Config.plugins[plugin];
+      const pluginsecret = Config.plugin_secrets[plugin];
+      plugins.append(Plugin(pluginconfig, pluginsecret));
+    }
+    return plugins;
+  }
+}
+
+module.exports = BasePlugin;

--- a/packages/server/src/integration-plugins/paperless.js
+++ b/packages/server/src/integration-plugins/paperless.js
@@ -1,0 +1,70 @@
+const log = require('loglevel').getLogger('Scan');
+
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
+
+const BasePlugin = require('./base');
+
+
+class Paperless {
+
+  constructor({hostname, token, use_https, port}) {
+    this.hostname = hostname;
+    this.token = token;
+    if (use_https === false) {
+      this.http = http;
+      this.port = port || 80;
+    } else {
+      this.http = https;
+      this.port = port || 443;
+    }
+  }
+
+  upload(filename) {
+    // https://paperless-ngx.readthedocs.io/en/latest/api.html#posting-documents
+    const options = {
+      hostname: this.hostname,
+      port: 443,
+      path: '/api/documents/post_document/',
+      method: 'POST',
+      headers: {
+        //'Content-Type': '',
+      },
+    };
+
+    const req = this.http.request(options, (res) => {
+      log.debug(`STATUS: ${res.statusCode}`);
+      log(`HEADERS: ${JSON.stringify(res.headers)}`);
+      res.setEncoding('utf8');
+
+    });
+    const form = req.form();
+    form.append('file', fs.createReadStream(filename));
+
+    req.on('error', (e) => {
+      log.error(`Paperless request failed: ${e.message}`);
+    });
+    return req.end();
+  }
+
+}
+
+
+class PaperlessPlugin extends BasePlugin {
+  name() {
+    return 'paperless';
+  }
+  onScan(fileInfo) {
+    const paperless = Paperless({
+      hostname: this.pluginconfig.hostname,
+      port: this.pluginconfig.port,
+      use_https: this.pluginconfig.use_https,
+      token: this.pluginsecret.token
+    });
+    paperless.upload(fileInfo.fullname);
+  }
+
+}
+
+module.exports = PaperlessPlugin;

--- a/packages/server/src/scan-controller.js
+++ b/packages/server/src/scan-controller.js
@@ -9,6 +9,7 @@ const Process = require('./process');
 const Request = require('./request');
 const Scanimage = require('./scanimage');
 const Util = require('./util');
+const BasePlugin = require('./integration-plugins/base');
 
 class ScanController {
   constructor() {
@@ -104,9 +105,11 @@ class ScanController {
     }
 
     const destination = `${Config.outputDirectory}/${Config.filename()}.${extension}`;
-    await FileInfo
-      .create(`${Config.tempDirectory}/${filename}`)
-      .move(destination);
+    const fileInfo = FileInfo.create(`${Config.tempDirectory}/${filename}`);
+    await fileInfo.move(destination);
+
+    // Run onScan for any registered Plugins
+    BasePlugin.runOnScan(fileInfo);
 
     log.debug(`Written data to: ${destination}`);
     await this.deleteFiles();


### PR DESCRIPTION
Hi @sbs20,

After wrestling with a robust way to get data from scanservjs to paperless and reviewing [the discussion here](https://github.com/sbs20/scanservjs/issues/351) as well as some of the existing solutions involving copying files, I thought I'd take a stab at putting together an unobtrusive way to build integrations directly into scanservjs.

Please note that this is an INCOMPLETE and UNTESTED proof-of-concept / draft, but I thought I'd run it by you sooner rather than later, since I am sure you are sensitive to merging in functionality that is secondary to the core purpose of scanservjs.

Please let me know if you like this direction enough that you might actually be open to merging it someday (once it's working)