### PR TITLE
Implement `--page-height` and `--page-width`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -261,23 +261,31 @@ module.exports = {
 }
 ```
 
-### Add custom scanimage command line options
+### Handling `--page-width` and `--page-height`
 
 Some scanners need
 [additional arguments](https://github.com/sbs20/scanservjs/issues/401) for
-scanimage to behave. It's possible to set them in the config using the
-`scanimageAdditionalArguments` key. This is a dictionary of key value pairs
-which will be applied as arguments.
-
-For the linked issue, the solution is to add:
+scanimage to behave. By default, the application _should_ just work. While the
+end user is not presented with an option to change these in the UI, the
+parameters will be automatically defaulted according to the values presented by
+SANE - and will do so **per device**. Should the values not be to your liking
+then you can override them as per any other device setting:
 
 ```javascript
 module.exports = {
-  afterConfig(config) {
-    config.scanimageAdditionalArguments = {
-      '--page-height': 297
-    };
-  }
+  afterDevices(devices) {
+    devices
+      .filter(d => d.id.includes('fujitsu'))
+      .forEach(device => {
+        device.features['--page-height'] = {
+          default: 297,
+          limits:  [0, 297]
+        };
+        device.features['--page-width'] = {
+          default: 215,
+          limits:  [0, 215]
+        };
+      });
 }
 ```
 

--- a/packages/client/src/classes/request.js
+++ b/packages/client/src/classes/request.js
@@ -24,12 +24,25 @@ export default class Request {
       index: 1
     };
 
-    if (['-x', '-y', '-l', '-t'].every(s => s in device.features)) {
-      obj.params.top = request.params.top || device.features['-t'].default;
-      obj.params.left = request.params.left || device.features['-l'].default;
+    if ('-x' in device.features) {
       obj.params.width = request.params.width || device.features['-x'].default;
+    }
+    if ('-y' in device.features) {
       obj.params.height = request.params.height || device.features['-y'].default;
     }
+    if ('-l' in device.features) {
+      obj.params.left = request.params.left || device.features['-l'].default;
+    }
+    if ('-t' in device.features) {
+      obj.params.top = request.params.top || device.features['-t'].default;
+    }
+    if ('--page-height' in device.features) {
+      obj.params.pageHeight = request.params.pageHeight || device.features['--page-height'].default;
+    }
+    if ('--page-width' in device.features) {
+      obj.params.pageWidth = request.params.pageWidth || device.features['--page-width'].default;
+    }
+    
     if ('--adf-mode' in device.features) {
       obj.params.adfMode = request.params.adfMode || device.features['--adf-mode'].default;
     }

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -50,8 +50,6 @@ class Config {
       previewDirectory: 'data/preview',
       tempDirectory: 'data/temp',
     
-      scanimageAdditionalArguments: {},
-
       users: {},
 
       previewResolution: 100,

--- a/packages/server/src/feature.js
+++ b/packages/server/src/feature.js
@@ -82,6 +82,8 @@ class Feature {
         case '-t':
         case '-x':
         case '-y':
+        case '--page-height':
+        case '--page-width':
           this.geometry();
           break;
         

--- a/packages/server/src/request.js
+++ b/packages/server/src/request.js
@@ -36,12 +36,25 @@ class Request {
       index: data.index || 1
     });
 
-    if (device.geometry) {
+    if ('-t' in features) {
       this.params.top = bound(data.params.top, features['-t'].limits[0], features['-t'].limits[1], 0);
-      this.params.left = bound(data.params.left, features['-l'].limits[0], features['-l'].limits[1], 0);
-      this.params.width = bound(data.params.width, features['-x'].limits[0], features['-x'].limits[1], features['-x'].limits[1]);
-      this.params.height = bound(data.params.height, features['-y'].limits[0], features['-y'].limits[1], features['-y'].limits[1]);
     }
+    if ('-l' in features) {
+      this.params.left = bound(data.params.left, features['-l'].limits[0], features['-l'].limits[1], 0);      
+    }
+    if ('-x' in features) {
+      this.params.width = bound(data.params.width, features['-x'].limits[0], features['-x'].limits[1], features['-x'].limits[1]);      
+    }
+    if ('-y' in features) {
+      this.params.height = bound(data.params.height, features['-y'].limits[0], features['-y'].limits[1], features['-y'].limits[1]);      
+    }
+    if ('--page-height' in features) {
+      this.params.pageHeight = bound(data.params.pageHeight, features['--page-height'].limits[0], features['--page-height'].limits[1], features['--page-height'].default);      
+    }
+    if ('--page-width' in features) {
+      this.params.pageWidth = bound(data.params.pageWidth, features['--page-width'].limits[0], features['--page-width'].limits[1], features['--page-width'].default);            
+    }
+
     if ('--mode' in features) {
       this.params.mode = data.params.mode || features['--mode'].default;
     }

--- a/packages/server/src/scanimage.js
+++ b/packages/server/src/scanimage.js
@@ -79,17 +79,23 @@ class ScanimageCommand {
     }
     cmdBuilder.arg('--resolution', params.resolution);
 
-    if ('scanimageAdditionalArguments' in Config) {
-      Object.entries(Config.scanimageAdditionalArguments).forEach(([key, value]) => {
-        cmdBuilder.arg(key, value);
-      });
+    if ('pageWidth' in params) {
+      cmdBuilder.arg('--page-width', params.pageWidth);
     }
-
-    if (['left', 'top', 'width', 'height'].every(s => s in params)) {
-      cmdBuilder.arg('-l', params.left)
-        .arg('-t', params.top)
-        .arg('-x', params.width)
-        .arg('-y', params.height);
+    if ('pageHeight' in params) {
+      cmdBuilder.arg('--page-height', params.pageHeight);
+    }
+    if ('left' in params) {
+      cmdBuilder.arg('-l', params.left);
+    }
+    if ('top' in params) {
+      cmdBuilder.arg('-t', params.top);
+    }
+    if ('width' in params) {
+      cmdBuilder.arg('-x', params.width);
+    }
+    if ('height' in params) {
+      cmdBuilder.arg('-y', params.height);
     }
 
     cmdBuilder.arg('--format', params.format);

--- a/packages/server/src/types.js
+++ b/packages/server/src/types.js
@@ -68,7 +68,6 @@
  * @property {boolean} devicesFind
  * @property {string} ocrLanguage
  * @property {string} scanimage
- * @property {Object.<string, string>} scanimageAdditionalArguments
  * @property {string} convert
  * @property {string} tesseract
  * @property {boolean} allowUnsafePaths

--- a/packages/server/src/types.yml
+++ b/packages/server/src/types.yml
@@ -525,6 +525,12 @@ definitions:
       height:
         type: integer
         example: 297
+      pageWidth:
+        type: integer
+        example: 215
+      pageHeight:
+        type: integer
+        example: 297
       resolution:
         type: integer
         example: 200
@@ -534,6 +540,9 @@ definitions:
       source:
         type: string
         example: 'Flatbed'
+      adfMode:
+        type: string
+        example: 'Simplex'
       brightness:
         type: integer
         example: 0

--- a/packages/server/test/device.test.js
+++ b/packages/server/test/device.test.js
@@ -215,6 +215,12 @@ describe('Device', () => {
     assert.strictEqual(device.features['--source'].default, 'ADF Front');
     assert.deepStrictEqual(device.features['--resolution'].options, [50, 75, 150, 300, 600]);
     assert.strictEqual(device.features['--resolution'].default, 300);
+    assert.strictEqual(device.features['--page-height'].limits[0], 0);
+    assert.strictEqual(device.features['--page-height'].limits[1], 450.7);
+    assert.strictEqual(device.features['--page-height'].default, 292);
+    assert.strictEqual(device.features['--page-width'].limits[0], 2.7);
+    assert.strictEqual(device.features['--page-width'].limits[1], 219.4);
+    assert.strictEqual(device.features['--page-width'].default, 215.8);
     assert.strictEqual(device.features['-l'], undefined);
     assert.strictEqual(device.features['-x'], undefined);
     assert.deepStrictEqual(device.features['-t'].limits, [0, 289.3]);
@@ -236,6 +242,8 @@ describe('Device', () => {
     assert.strictEqual(device.features['--adf-mode'].default, 'Simplex');
     assert.deepStrictEqual(device.features['--resolution'].options, [75, 100, 150, 300, 600, 1200]);
     assert.strictEqual(device.features['--resolution'].default, 75);
+    assert.strictEqual(device.features['--page-height'], undefined);
+    assert.strictEqual(device.features['--page-width'], undefined);
     assert.strictEqual(device.features['-l'].limits[0], 0);
     assert.strictEqual(device.features['-l'].limits[1], 297.1);
     assert.strictEqual(device.features['-l'].default, 0);

--- a/packages/server/test/request.test.js
+++ b/packages/server/test/request.test.js
@@ -102,4 +102,37 @@ describe('Request', () => {
     assert.strictEqual(request.params.dynamicLineart, undefined);
   });
 
+  it('scanimage-a10.txt', () => {
+    const file = FileInfo.create('test/resource/scanimage-a10.txt');
+    const device = Device.from(file.toText());
+    const context = new Context([device]);
+    const request = new Request(context).extend({
+      params: {
+        top: -1,
+        left: -20,
+        width: 400,
+        height: 400,
+        resolution: '150',
+        mode: 'Color',
+        brightness: 0,
+        contrast: 0,
+        dynamicLineart: true
+      },
+      pipeline: 'test-pipeline'
+    });
+    
+    assert.strictEqual(request.params.deviceId, 'epjitsu:libusb:001:003');
+    assert.strictEqual(request.params.mode, 'Color');
+    assert.strictEqual(request.params.resolution, '150');
+    assert.strictEqual(request.params.left, undefined);
+    assert.strictEqual(request.params.top, 0);
+    assert.strictEqual(request.params.width, undefined);
+    assert.strictEqual(request.params.height, undefined);
+    assert.strictEqual(request.params.pageWidth, 215.8);
+    assert.strictEqual(request.params.pageHeight, 292);
+    assert.strictEqual(request.params.brightness, 0);
+    assert.strictEqual(request.params.contrast, 0);
+    assert.strictEqual(request.params.dynamicLineart, undefined);
+  });
+
 });

--- a/packages/server/test/scanimage-test.js
+++ b/packages/server/test/scanimage-test.js
@@ -1,5 +1,9 @@
 /* eslint-env mocha */
 const assert = require('assert');
+const Context = require('../src/context');
+const Device = require('../src/device');
+const FileInfo = require('../src/file-info');
+const Request = require('../src/request');
 const Scanimage = require('../src/scanimage');
 
 const requestScan = {
@@ -57,5 +61,20 @@ describe('ScanimageCommand', () => {
   it('scanimageVersion:1.0.31:preview', () => {
     const command = commandFor('1.0.31', requestPreview);
     assert.ok(command.match(/.*scanimage.* -o 'data\/preview\/preview.tif'/));
+  });
+
+  it('scanimage-a10.txt', () => {
+    const file = FileInfo.create('test/resource/scanimage-a10.txt');
+    const device = Device.from(file.toText());
+    const context = new Context([device]);
+    const request = new Request(context).extend({
+      params: {
+        mode: 'Color'
+      }
+    });
+    const command = commandFor('1.0.31', request);
+
+    // eslint-disable-next-line quotes
+    assert.strictEqual(command, `/usr/bin/scanimage -d 'epjitsu:libusb:001:003' --mode 'Color' --source 'ADF Front' --resolution 300 --page-width 215.8 --page-height 292 -t 0 --format 'tiff' --brightness 0 --contrast 0 -o 'data/temp/~tmp-scan-0-0001.tif'`);
   });
 });


### PR DESCRIPTION
Issue #401

The original fix for #401 involved adding additional arguments for `scanimage` but globally. This had a bad side-effect for users with multiple scanners with differing characteristics.

The new solution treats these additional parameters as first class citizens and automatically adds them as required. The UI still does not present the user with the ability to override the values - although the API supports it should that become a requirement in the future. As a result the app always uses the default values provided by SANE.

The net result is that `scanimageAdditionalParameters` has been removed and is ignored. And no customisation should be required at all. However, in the event that the values provided by SANE are unsatisfactory, then it is possible to override the value as per all other device customisation - this has been noted in the `config.md` doc.

Other changes:
* Updated the yml used by swagger to refect the new parameters
* There is more granular checking of the individual geometry elements now - the previous behaviour relied on a bad assumption that `x`, `y`, `t` and `l` were always there or always not.
* Additional unit tests