### PR TITLE
Add description of pipeline mechanism

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -164,7 +164,18 @@ can be anything you want it to be. You just need to override it.
 ### Insert your own pipelines
 
 You may wish to add your own custom pipelines. Pipelines are arrays of shell
-commands which run after scans. To learn more read the
+commands which run after scans.
+
+The pipeline commands will be started subsequently but in separate subprocesses. 
+Therefore, e.g., the definition of variables in one line, can't be accessed in another.
+If you want full scripting capabilities, create a script externally (e.g. in /usr/local/bin), 
+make it executable, and start it here. The script will be executed from the tmp-folder of scanservjs,
+thus, it can access all temporary files. Alternatively, a script can also request parameters, which can be set here.
+
+You are free to create whatever kind of files you want, however, the last command of the pipeline needs to
+return a list of files, which can be further processed by scanservjs to create the final result within scanservjs.
+
+To learn more read the
 [example source](../packages/server/config/config.default.js). This will insert
 your own pipelines at the top of the list.
 


### PR DESCRIPTION
The pipeline commands aren't scripts. 
This PR makes it more clear in the docs.
E.g. using a shell variable in one line, it can't be accessed in another line. That is particular problematic, as empty shell variables silently return nothing. Commands might not execute or, even worse, completely wrong. E.g. rclone cp ./${foo} /path/desitination/ will copy the entire content of the tmp folder instead of the file which is named in foo.