### PR TITLE
Improve Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN npm run build
 # ==============================================================================
 FROM node:16-bullseye-slim AS scanservjs-base
 RUN apt-get update \
-  && apt-get install --no-install-recommends -yq \
+  && apt-get install -yq \
     imagemagick \
     sane \
     sane-utils \
@@ -41,13 +41,15 @@ RUN apt-get update \
     tesseract-ocr-tur \
     tesseract-ocr-chi-sim \
     sane-airscan \
+    ipp-usb \
+  && rm -rf /var/lib/apt/lists/* \
   && sed -i \
     's/policy domain="coder" rights="none" pattern="PDF"/policy domain="coder" rights="read | write" pattern="PDF"'/ \
     /etc/ImageMagick-6/policy.xml \
   && sed -i \
     's/policy domain="resource" name="disk" value="1GiB"/policy domain="resource" name="disk" value="8GiB"'/ \
     /etc/ImageMagick-6/policy.xml \
-  && npm install -g npm@8.3.0 && npm cache clean --force; && rm -rf /var/lib/apt/lists/*;
+  && npm install -g npm@8.3.0 && npm cache clean --force;
 
 # Core image
 #
@@ -114,7 +116,7 @@ FROM scanservjs-core
 # default - you will need to specifically target it.
 # ==============================================================================
 FROM scanservjs-core AS scanservjs-hplip
-RUN apt-get install --no-install-recommends -yq libsane-hpaio \
+RUN apt-get update && apt-get install -yq libsane-hpaio \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && echo hpaio >> /etc/sane.d/dll.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN npm run build
 # ==============================================================================
 FROM node:16-bullseye-slim AS scanservjs-base
 RUN apt-get update \
-  && apt-get install -yq \
+  && apt-get install --no-install-recommends -yq \
     imagemagick \
     sane \
     sane-utils \
@@ -47,7 +47,7 @@ RUN apt-get update \
   && sed -i \
     's/policy domain="resource" name="disk" value="1GiB"/policy domain="resource" name="disk" value="8GiB"'/ \
     /etc/ImageMagick-6/policy.xml \
-  && npm install -g npm@8.3.0
+  && npm install -g npm@8.3.0 && npm cache clean --force; && rm -rf /var/lib/apt/lists/*;
 
 # Core image
 #
@@ -79,7 +79,7 @@ ENTRYPOINT [ "/run.sh" ]
 
 # Copy the code and install
 COPY --from=scanservjs-build "$APP_DIR/dist" "$APP_DIR/"
-RUN npm install --production
+RUN npm install --production && npm cache clean --force;
 
 EXPOSE 8080
 
@@ -114,7 +114,7 @@ FROM scanservjs-core
 # default - you will need to specifically target it.
 # ==============================================================================
 FROM scanservjs-core AS scanservjs-hplip
-RUN apt-get install -yq libsane-hpaio \
+RUN apt-get install --no-install-recommends -yq libsane-hpaio \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && echo hpaio >> /etc/sane.d/dll.conf


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

Summary of the changes:
* I added `npm cache clean` after `npm install` to remove `npm` cache that is not needed inside the Docker image.
* I added the `--no-install-recommends` to with apt-get in order to not install unnecessary packages and reduce the image size.
* Running apt-get update and apt-get install in a single layer in a Dockerfile improves efficiency, reliability, and readability.
* I added `rm -rf /var/lib/apt/lists/*` after `apt-get install` which removes unnecessary files and reduces the size of the image.


Impact on the image size (default build):
* Image size before repair: 1.04 GB
* Image size after repair: 643.25 MB
* Difference: 419.13 MB (39.45%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,