### PR TITLE
ci(docker): publish semver compatible tags sbs20/scanservjs#529

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,13 +24,13 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-        
+
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        
+
       - name: Push master (to staging)
         if: github.ref == 'refs/heads/master'
         uses: docker/build-push-action@v2
@@ -52,6 +52,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/scanservjs:release-${{ steps.get_version.outputs.VERSION }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/scanservjs:${{ steps.get_version.outputs.VERSION }}
             ${{ secrets.DOCKERHUB_USERNAME }}/scanservjs:latest
           target: scanservjs-core
           platforms: linux/amd64,linux/arm64,linux/arm/v7


### PR DESCRIPTION
:wave: hi @sbs20,

here the PR for #529

My linter has changed a few more lines (trailing whitespaces) let me know if I should revert them.

I have kept the "original" tag, and just added the semver tag, to not break with possible existing update workflows.