### PR TITLE
Per device settings

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -80,7 +80,8 @@ module.exports = {
         device.features['--brightness'].default = 0;
         device.features['--contrast'].default = 5;
         device.features['-x'].default = 215;
-        device.features['-y'].default = 297;  
+        device.features['-y'].default = 297;
+        device.settings.batchMode.options = ['none'];
       });
   }
 
@@ -298,6 +299,47 @@ module.exports = {
         };
       });
 }
+```
+
+### Override batchMode, filters and pipelines
+
+Devices also have their own batch modes, filters and pipelines. By default, each
+device inherits the settings in `config`.
+
+```javascript
+device.settings = {
+  batchMode: {
+    options: config.batchModes,
+    default: config.batchModes[0]
+  },
+  filters: {
+    options: config.filters.map(f => f.description),
+    default: []
+  },
+  pipeline: {
+    options: config.pipelines.map(p => p.description),
+    default: config.pipelines[0].description
+  }
+};
+```
+
+But it's possible to override these settings to limit the options available to a
+specific device or change the default. So just as with other device overrides:
+
+```javascript
+  /**
+   * @param {ScanDevice[]} devices 
+   */
+  afterDevices(devices) {
+    // Override the defaults for plustek scanners
+    devices
+      .filter(d => d.id.includes('plustek'))
+      .forEach(device => {
+        device.settings.batchMode.options = ['none'];
+        device.settings.batchMode.default = 'none';
+        device.settings.filters.default = ['filter.threshold'];
+      });
+  }
 ```
 
 ### Add Basic Authentication

--- a/packages/client/src/classes/device.js
+++ b/packages/client/src/classes/device.js
@@ -37,6 +37,20 @@ export default {
           limits: [-100, 100],
         },
         '--disable-dynamic-lineart': {}
+      },
+      settings: {
+        batchMode: {
+          options: [],
+          default: ''
+        },
+        filters: {
+          options: [],
+          default: []
+        },
+        pipeline: {
+          options: [],
+          default: ''
+        }
       }
     };
   }

--- a/packages/client/src/classes/request.js
+++ b/packages/client/src/classes/request.js
@@ -1,69 +1,74 @@
 import Constants from './constants';
 
 export default class Request {
+
   /**
    * @param {Request} request 
-   * @param {Device} device 
-   * @param {string} pipeline 
-   * @param {string} batchMode
-   * @returns 
+   * @param {Device} device
    */
-  static create(request, device, pipeline, batchMode) {
+  constructor(request, device) {
     request = request || {};
     request.params = request.params || {};
 
-    const obj = {
+    Object.assign(this, {
       version: Constants.Version,
       params: {
         deviceId: device.id,
         resolution: request.params.resolution || device.features['--resolution'].default
       },
-      filters: request.filters || [],
-      pipeline: request.pipeline || pipeline,
-      batch: request.batch || (batchMode === undefined ? 'none' : batchMode),
+      filters: request.filters || device.settings.filters.default,
+      pipeline: request.pipeline || device.settings.pipeline.default,
+      batch: request.batch || device.settings.batchMode.default,
       index: 1
-    };
+    });
 
     if ('-x' in device.features) {
-      obj.params.width = request.params.width || device.features['-x'].default;
+      this.params.width = request.params.width || device.features['-x'].default;
     }
     if ('-y' in device.features) {
-      obj.params.height = request.params.height || device.features['-y'].default;
+      this.params.height = request.params.height || device.features['-y'].default;
     }
     if ('-l' in device.features) {
-      obj.params.left = request.params.left || device.features['-l'].default;
+      this.params.left = request.params.left || device.features['-l'].default;
     }
     if ('-t' in device.features) {
-      obj.params.top = request.params.top || device.features['-t'].default;
+      this.params.top = request.params.top || device.features['-t'].default;
     }
     if ('--page-height' in device.features) {
-      obj.params.pageHeight = request.params.pageHeight || device.features['--page-height'].default;
+      this.params.pageHeight = request.params.pageHeight || device.features['--page-height'].default;
     }
     if ('--page-width' in device.features) {
-      obj.params.pageWidth = request.params.pageWidth || device.features['--page-width'].default;
+      this.params.pageWidth = request.params.pageWidth || device.features['--page-width'].default;
     }
     
     if ('--adf-mode' in device.features) {
-      obj.params.adfMode = request.params.adfMode || device.features['--adf-mode'].default;
+      this.params.adfMode = request.params.adfMode || device.features['--adf-mode'].default;
     }
     if ('--mode' in device.features) {
-      obj.params.mode = request.params.mode || device.features['--mode'].default;
+      this.params.mode = request.params.mode || device.features['--mode'].default;
     }
     if ('--source' in device.features) {
-      obj.params.source = request.params.source || device.features['--source'].default;
+      this.params.source = request.params.source || device.features['--source'].default;
     }
     if ('--brightness' in device.features) {
-      obj.params.brightness = request.params.brightness || device.features['--brightness'].default;
+      this.params.brightness = request.params.brightness || device.features['--brightness'].default;
     }
     if ('--contrast' in device.features) {
-      obj.params.contrast = request.params.contrast || device.features['--contrast'].default;
+      this.params.contrast = request.params.contrast || device.features['--contrast'].default;
     }
     if ('--disable-dynamic-lineart' in device.features) {
-      obj.params.dynamicLineart = request.params.dynamicLineart !== undefined
+      this.params.dynamicLineart = request.params.dynamicLineart !== undefined
         ? request.params.dynamicLineart
         : true;
     }
+  }
 
-    return obj;
+  /**
+   * @param {Request} request 
+   * @param {Device} device
+   * @returns 
+   */
+  static create(request, device) {
+    return new Request(request, device);
   }
 }

--- a/packages/client/src/components/Scan.vue
+++ b/packages/client/src/components/Scan.vue
@@ -159,16 +159,13 @@ export default {
   data() {
     const device = Device.default();
     device.name = this.$t('global.no-data-text');
-    const request = Request.create(null, device, '');
+    const request = Request.create(null, device);
 
     return {
       context: {
         devices: [
           device
         ],
-        batchModes: [],
-        filters: [],
-        pipelines: [],
         paperSizes: [],
         version: '0'
       },
@@ -200,14 +197,14 @@ export default {
     },
 
     deviceSize() {
-      return {
+      return !this.geometry ? undefined : {
         width: this.device.features['-x'].limits[1],
         height: this.device.features['-y'].limits[1]
       };
     },
 
     batchModes() {
-      return this.context.batchModes.map(mode => {
+      return this.device.settings.batchMode.options.map(mode => {
         const key = `batch-mode.${sanitiseLocaleKey(mode)}`;
         let translation = this.$t(key);
         return {
@@ -218,7 +215,7 @@ export default {
     },
 
     filters() {
-      return this.context.filters.map(f => {
+      return this.device.settings.filters.options.map(f => {
         return {
           text: this.$te(f) ? this.$t(f) : f,
           value: f
@@ -227,26 +224,34 @@ export default {
     },
 
     modes() {
-      return this.device.features['--mode'].options.map(mode => {
-        const key = `mode.${sanitiseLocaleKey(mode)}`;
-        return {
-          text: this.$te(key) ? this.$t(key) : mode,
-          value: mode
-        };
-      });
+      return '--mode' in this.device.features
+        ? this.device.features['--mode'].options.map(mode => {
+          const key = `mode.${sanitiseLocaleKey(mode)}`;
+          return {
+            text: this.$te(key) ? this.$t(key) : mode,
+            value: mode
+          };
+        })
+        : undefined;
     },
 
     adfModes() {
-      return this.device.features['--adf-mode'].options.map(adfMode => {
-        const key = `adf-mode.${sanitiseLocaleKey(adfMode)}`;
-        return {
-          text: this.$te(key) ? this.$t(key) : adfMode,
-          value: adfMode
-        };
-      });
+      return '--adf-mode' in this.device.features
+        ? this.device.features['--adf-mode'].options.map(adfMode => {
+          const key = `adf-mode.${sanitiseLocaleKey(adfMode)}`;
+          return {
+            text: this.$te(key) ? this.$t(key) : adfMode,
+            value: adfMode
+          };
+        })
+        : undefined;
     },
 
     paperSizes() {
+      if (!this.geometry) {
+        return undefined;
+      }
+
       const deviceSize = {
         x: this.device.features['-x'].limits[1],
         y: this.device.features['-y'].limits[1]
@@ -264,7 +269,7 @@ export default {
     },
 
     pipelines() {
-      return this.context.pipelines.map(p => {
+      return this.device.settings.pipeline.options.map(p => {
         const variables = (p.match(/@:[a-z-.]+/ig) || []).map(s => s.substr(2));
         let text = p;
         variables.forEach(v => {
@@ -279,14 +284,16 @@ export default {
     },
 
     sources() {
-      return this.device.features['--source'].options.map(source => {
-        const key = `source.${sanitiseLocaleKey(source)}`;
-        const x =  {
-          text: this.$te(key) ? this.$t(key) : source,
-          value: source
-        };
-        return x;
-      });
+      return '--source' in this.device.features
+        ? this.device.features['--source'].options.map(source => {
+          const key = `source.${sanitiseLocaleKey(source)}`;
+          const x =  {
+            text: this.$te(key) ? this.$t(key) : source,
+            value: source
+          };
+          return x;
+        })
+        : undefined;
     }
   },
 
@@ -513,7 +520,7 @@ export default {
           || this.context.devices[0];
       }
 
-      request = Request.create(request, this.device, this.context.pipelines[0]);
+      request = Request.create(request, this.device);
       return request;
     },
 

--- a/packages/server/.eslintrc.json
+++ b/packages/server/.eslintrc.json
@@ -20,7 +20,8 @@
       "error",
       2,
       {
-        "SwitchCase": 1
+        "SwitchCase": 1,
+        "flatTernaryExpressions": true
       }
     ],
     "keyword-spacing": 1,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,7 +6,8 @@
     "lint": "gulp lint",
     "build": "gulp build",
     "package": "gulp package",
-    "serve": "nodemon -e js,yml --watch src --exec 'npm run build && node ./src/server.js'",
+    "serve": "npm run build && node ./src/server.js",
+    "serve-nodemon": "nodemon -e js,yml --watch src --exec 'npm run build && node ./src/server.js'",
     "test": "mocha"
   },
   "main": "server/server.js",

--- a/packages/server/src/api.js
+++ b/packages/server/src/api.js
@@ -112,7 +112,10 @@ module.exports = new class Api {
    */
   async readThumbnail(name) {
     const source = FileInfo.unsafe(config.outputDirectory, name);
-    return await Process.spawn(`convert '${source.fullname}'[0] -resize 256 -quality 75 jpg:-`);
+    if (source.extension !== '.zip') {
+      return await Process.spawn(`convert '${source.fullname}'[0] -resize 256 -quality 75 jpg:-`);
+    }
+    return [];
   }
 
   /**
@@ -135,10 +138,7 @@ module.exports = new class Api {
    * @returns {Promise.<Context>}
    */
   async readContext() {
-    const context = await application.context();
-    context.filters = context.filters.map(f => f.description);
-    context.pipelines = context.pipelines.map(p => p.description);
-    return context;
+    return await application.context();
   }
 
   /**

--- a/packages/server/src/application.js
+++ b/packages/server/src/application.js
@@ -18,7 +18,7 @@ module.exports = new class Application {
 
   userOptions() {
     if (this._userOptions === null) {
-      this._userOptions = new UserOptions();
+      this._userOptions = new UserOptions('../../config/config.local.js');
     }
     return this._userOptions;
   }
@@ -104,7 +104,6 @@ module.exports = new class Application {
       file.save(JSON.stringify(devices.map(d => d.string), null, 2));
     }
 
-    this.userOptions().afterDevices(devices);
     return devices;
   }
 
@@ -123,7 +122,7 @@ module.exports = new class Application {
    */
   async context() {
     const devices = await this.deviceList();
-    return new Context(this.config(), devices);
+    return new Context(this.config(), devices, this.userOptions());
   }
 
   system() {

--- a/packages/server/src/classes/object-merger.js
+++ b/packages/server/src/classes/object-merger.js
@@ -1,0 +1,17 @@
+function deepMerge(...objects) {
+  return objects.reduce((acc, cur) => {
+    return typeof cur === 'undefined' ? acc :
+      Array.isArray(cur) || typeof cur !== 'object' ? cur :
+      Object.entries(cur).reduce((acc, kv) => {
+        const [key, value] = kv;
+        acc[key] = key in acc ? deepMerge(acc[key], value) : value;
+        return acc;
+      }, acc);
+  });
+}
+
+module.exports = new class ObjectMerger {
+  deepMerge(...objects) {
+    return deepMerge(...objects);
+  }
+};

--- a/packages/server/src/classes/user-options.js
+++ b/packages/server/src/classes/user-options.js
@@ -2,10 +2,12 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = class UserOptions {
-  constructor() {
-    const localPath = path.join(__dirname, '../../config/config.local.js');
-    if (fs.existsSync(localPath)) {
-      this.local = require(localPath);
+  constructor(localConfigPath) {
+    if (localConfigPath) {
+      const localPath = path.join(__dirname, localConfigPath);
+      if (fs.existsSync(localPath)) {
+        this.local = require(localPath);
+      }
     }
   }
 

--- a/packages/server/src/scan-controller.js
+++ b/packages/server/src/scan-controller.js
@@ -29,8 +29,7 @@ class ScanController {
   async init(req) {
     this.context = await application.context();
     this.request = new Request(this.context).extend(req);
-    // Check pipeline here. Better to find out sooner if there's a problem
-    this.pipeline = this.context.pipelines
+    this.pipeline = config.pipelines
       .filter(p => p.description === this.request.pipeline)[0];
     if (this.pipeline === undefined) {
       throw Error('No matching pipeline');

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -11,7 +11,7 @@ configure(app);
 
 const server = app.listen(config.port, config.host, () => {
   const log = require('loglevel').getLogger('server');
-  log.info('Started');
+  log.info(`scanservjs started listening: https://${config.host}:${config.port}`);
 });
 
 server.setTimeout(config.timeout);

--- a/packages/server/src/swagger.yml
+++ b/packages/server/src/swagger.yml
@@ -290,6 +290,10 @@ definitions:
         type: object
         additionalProperties:
           $ref: '#/definitions/Feature'
+      settings:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/Feature'
     example:
       "id": "plustek:libusb:001:004"
       "name": "plustek:libusb:001:004"
@@ -384,7 +388,33 @@ definitions:
             - -100
             - 100        
           "interval": 1
-  
+
+      "settings":
+        "batchMode":
+          "options":
+            - 'none'
+            - 'manual'
+            - 'auto'
+            - 'auto-collate-standard'
+          
+          "default": 'none'
+        
+        "filters":
+          "options":
+            - 'filter.auto-level'
+            - 'filter.threshold'
+            - 'filter.blur'
+
+          "default": []
+        
+        "pipeline":
+          "options":
+            - 'JPG | @:pipeline.high-quality'
+            - 'JPG | @:pipeline.medium-quality'
+            - 'JPG | @:pipeline.low-quality'
+
+          "default": 'JPG | AMAZING quality'
+
   Context:
     properties:
       version:
@@ -396,50 +426,10 @@ definitions:
         items:
           $ref: '#/definitions/Device'
 
-      pipelines:
-        type: array
-        items:
-          type: string
-        example:
-          - 'JPG | @:pipeline.high-quality'
-          - 'JPG | @:pipeline.medium-quality'
-          - 'JPG | @:pipeline.low-quality'
-          - 'PNG'
-          - 'TIF | @:pipeline.uncompressed'
-          - 'TIF | @:pipeline.lzw-compressed'
-          - 'PDF (TIF | @:pipeline.uncompressed)'
-          - 'PDF (TIF | @:pipeline.lzw-compressed)'
-          - 'PDF (JPG | @:pipeline.high-quality)'
-          - 'PDF (JPG | @:pipeline.medium-quality)'
-          - 'PDF (JPG | @:pipeline.low-quality)'
-          - '@:pipeline.ocr | PDF (JPG | @:pipeline.high-quality)'
-          - '@:pipeline.ocr | @:pipeline.text-file'
-
-      filters:
-        type: array
-        items:
-          type: string
-        example:
-          - 'filter.auto-level'
-          - 'filter.threshold'
-          - 'filter.blur'
-          - 'Rotate 90'
-
       paperSizes:
         type: array
         items:
           type: object
-
-      batchModes:
-        type: array
-        items:
-          type: string
-        example:
-          - 'none'
-          - 'manual'
-          - 'auto'
-          - 'auto-collate-standard'
-          - 'auto-collate-reverse'
 
   SystemInfoOs:
     properties:

--- a/packages/server/src/types.js
+++ b/packages/server/src/types.js
@@ -27,9 +27,7 @@
  * @property {string} string
  * @property {boolean} geometry
  * @property {Object.<string, ScanDeviceFeature>} features
- * @property {string|undefined} defaultBatchMode
- * @property {string|undefined} defaultFormat
- * @property {string|undefined} defaultFilters
+ * @property {Object.<string, ScanDeviceFeature>} settings
  */
 
 /**

--- a/packages/server/test/context.test.js
+++ b/packages/server/test/context.test.js
@@ -1,17 +1,233 @@
 /* eslint-env mocha */
 const assert = require('assert');
-const Application = require('../src/application');
 const Context = require('../src/classes/context');
+const UserOptions = require('../src/classes/user-options');
 
-const config = Application.config();
+const application = require('../src/application');
+application._userOptions = new UserOptions();
+
+const config = application.config();
 
 describe('Context', () => {
   it('missing files', () => {
     const temp = config.scanimage;
     config.scanimage = '/x';
-    const context = new Context(config, []);
+    const context = new Context(config, [], new UserOptions());
     assert.strictEqual(context.diagnostics.length, 2);
     assert.strictEqual(context.diagnostics[0].success, false);
     config.scanimage = temp;
+  });
+
+  it('settings:default', () => {
+    const device = {
+      id: 'test-scanner',
+      features: {
+        '--resolution': {
+          default: 50,
+          options: [50, 75]
+        },
+      }
+    };
+
+    const context = new Context(config, [device], new UserOptions());
+    assert.strictEqual(context.devices.length, 1);
+    assert.deepStrictEqual(context.devices[0].settings, {
+      batchMode: {
+        options: [
+          'none',
+          'manual',
+          'auto',
+          'auto-collate-standard'
+        ],
+        default: 'none'
+      },
+      filters: {
+        options: [
+          'filter.auto-level',
+          'filter.threshold',
+          'filter.blur'
+        ],
+        default: []
+      },
+      pipeline: {
+        options: [
+          'JPG | @:pipeline.high-quality',
+          'JPG | @:pipeline.medium-quality',
+          'JPG | @:pipeline.low-quality',
+          'PNG',
+          'TIF | @:pipeline.uncompressed',
+          'TIF | @:pipeline.lzw-compressed',
+          'PDF (TIF | @:pipeline.uncompressed)',
+          'PDF (TIF | @:pipeline.lzw-compressed)',
+          'PDF (JPG | @:pipeline.high-quality)',
+          'PDF (JPG | @:pipeline.medium-quality)',
+          'PDF (JPG | @:pipeline.low-quality)',
+          '@:pipeline.ocr | PDF (JPG | @:pipeline.high-quality)',
+          '@:pipeline.ocr | @:pipeline.text-file'
+        ],
+        default: 'JPG | @:pipeline.high-quality'
+      }
+    });
+  });
+
+  it('settings:override', () => {
+    const device = {
+      id: 'test-scanner',
+      features: {
+        '--resolution': {
+          default: 50,
+          options: [50, 75]
+        },
+      }
+    };
+
+    const userOptions = new UserOptions();
+    userOptions.afterDevices = (devices) => {
+      devices.forEach(device => {
+        device.settings.batchMode.default = 'banana';
+        device.settings.filters.options = [
+          'filter.auto-level'
+        ];
+        device.settings.pipeline = {
+          options: [
+            'JPG | @:pipeline.low-quality'
+          ],
+          default: 'JPG | @:pipeline.low-quality'
+        };
+      });
+    };
+
+    const context = new Context(config, [device], userOptions);
+    assert.strictEqual(context.devices.length, 1);
+    assert.deepStrictEqual(context.devices[0].settings, {
+      batchMode: {
+        options: [
+          'none',
+          'manual',
+          'auto',
+          'auto-collate-standard'
+        ],
+        default: 'banana'
+      },
+      filters: {
+        options: [
+          'filter.auto-level'
+        ],
+        default: []
+      },
+      pipeline: {
+        options: [
+          'JPG | @:pipeline.low-quality'
+        ],
+        default: 'JPG | @:pipeline.low-quality'
+      }
+    });
+  });
+
+  it('settings:override-and-new', () => {
+    const device = {
+      id: 'test-scanner',
+      features: {
+        '--resolution': {
+          default: 50,
+          options: [50, 75]
+        },
+      }
+    };
+
+    const userOptions = new UserOptions();
+    userOptions.afterDevices = (devices) => {
+      devices.forEach(device => {
+        device.settings.batchMode.default = 'banana';
+        device.settings.filters.options = [
+          'filter.auto-level'
+        ];
+        device.settings.pipeline = {
+          options: [
+            'JPG | @:pipeline.low-quality'
+          ],
+          default: 'JPG | @:pipeline.low-quality'
+        };
+      });
+
+      devices.push({
+        id: 'test-scanner-new',
+        features: {
+          '--resolution': {
+            default: 50,
+            options: [50, 75]
+          },
+        },
+        settings: {
+          batchMode: {
+            default: 'auto'
+          }
+        }
+      });
+    };
+
+    const context = new Context(config, [device], userOptions);
+    assert.strictEqual(context.devices.length, 2);
+    assert.deepStrictEqual(context.devices[0].settings, {
+      batchMode: {
+        options: [
+          'none',
+          'manual',
+          'auto',
+          'auto-collate-standard'
+        ],
+        default: 'banana'
+      },
+      filters: {
+        options: [
+          'filter.auto-level'
+        ],
+        default: []
+      },
+      pipeline: {
+        options: [
+          'JPG | @:pipeline.low-quality'
+        ],
+        default: 'JPG | @:pipeline.low-quality'
+      }
+    });
+
+    assert.deepStrictEqual(context.devices[1].settings, {
+      batchMode: {
+        options: [
+          'none',
+          'manual',
+          'auto',
+          'auto-collate-standard'
+        ],
+        default: 'auto'
+      },
+      filters: {
+        options: [
+          'filter.auto-level',
+          'filter.threshold',
+          'filter.blur'
+        ],
+        default: []
+      },
+      pipeline: {
+        options: [
+          'JPG | @:pipeline.high-quality',
+          'JPG | @:pipeline.medium-quality',
+          'JPG | @:pipeline.low-quality',
+          'PNG',
+          'TIF | @:pipeline.uncompressed',
+          'TIF | @:pipeline.lzw-compressed',
+          'PDF (TIF | @:pipeline.uncompressed)',
+          'PDF (TIF | @:pipeline.lzw-compressed)',
+          'PDF (JPG | @:pipeline.high-quality)',
+          'PDF (JPG | @:pipeline.medium-quality)',
+          'PDF (JPG | @:pipeline.low-quality)',
+          '@:pipeline.ocr | PDF (JPG | @:pipeline.high-quality)',
+          '@:pipeline.ocr | @:pipeline.text-file'
+        ],
+        default: 'JPG | @:pipeline.high-quality'
+      }
+    });
   });
 });

--- a/packages/server/test/object-merger.test.js
+++ b/packages/server/test/object-merger.test.js
@@ -1,0 +1,51 @@
+/* eslint-env mocha */
+const assert = require('assert');
+const ObjectMerger = require('../src/classes/object-merger');
+
+const target = {
+  a: 0,
+  c: {
+    x: 0,
+    y: 0
+  },
+  d: [0, 1, 2],
+  e: [1, 2, 4]
+};
+
+const source = {
+  a: 1,
+  b: 1,
+  c: {
+    x: 1
+  },
+  e: [1]
+};
+
+describe('ObjectMerger', () => {
+  it('Object assign', () => {
+    const result = ObjectMerger.deepMerge({}, target, source);
+    assert.deepStrictEqual(result, {
+      a: 1, // overwritten
+      b: 1, // added
+      c: { // merged
+        x: 1, // overwritten
+        y: 0 // left
+      },
+      d: [0, 1, 2], // left
+      e: [1] // overwritten
+    });
+  });
+
+  it('Deep merge', () => {
+    const result = Object.assign({}, target, source);
+    assert.deepStrictEqual(result, {
+      a: 1, // overwritten
+      b: 1, // added
+      c: { // overwritten
+        x: 1
+      },
+      d: [0, 1, 2], // left
+      e: [1] // overwritten
+    });
+  });
+});

--- a/packages/server/test/request.test.js
+++ b/packages/server/test/request.test.js
@@ -5,6 +5,7 @@ const Context = require('../src/classes/context');
 const Device = require('../src/classes/device');
 const FileInfo = require('../src/classes/file-info');
 const Request = require('../src/classes/request');
+const UserOptions = require('../src/classes/user-options');
 
 const config = Application.config();
 
@@ -12,7 +13,7 @@ describe('Request', () => {
   it('scanimage-a1.txt', () => {
     const file = FileInfo.create('test/resource/scanimage-a1.txt');
     const device = Device.from(file.toText());
-    const context = new Context(config, [device]);
+    const context = new Context(config, [device], new UserOptions());
     const request = new Request(context).extend({
       params: {
         deviceId: 'plustek:libusb:001:008',
@@ -26,7 +27,7 @@ describe('Request', () => {
         contrast: 0,
         dynamicLineart: true
       },
-      pipeline: 'test-pipeline'
+      pipeline: config.pipelines[0].description
     });
 
     assert.strictEqual(request.params.deviceId, 'plustek:libusb:001:008');
@@ -44,7 +45,7 @@ describe('Request', () => {
   it('scanimage-a1-defaults.txt', () => {
     const file = FileInfo.create('test/resource/scanimage-a1.txt');
     const device = Device.from(file.toText());
-    const context = new Context(config, [device]);
+    const context = new Context(config, [device], new UserOptions());
     const request = new Request(context).extend({
       params: {
         deviceId: 'plustek:libusb:001:008',
@@ -53,7 +54,7 @@ describe('Request', () => {
         contrast: 0,
         dynamicLineart: true
       },
-      pipeline: 'test-pipeline'
+      pipeline: config.pipelines[0].description
     });
 
     assert.strictEqual(request.params.deviceId, 'plustek:libusb:001:008');
@@ -71,7 +72,7 @@ describe('Request', () => {
   it('scanimage-a2.txt', () => {
     const file = FileInfo.create('test/resource/scanimage-a2.txt');
     const device = Device.from(file.toText());
-    const context = new Context(config, [device]);
+    const context = new Context(config, [device], new UserOptions());
     const request = new Request(context).extend({
       params: {
         deviceId: 'epson2:libusb:001:029',
@@ -85,7 +86,7 @@ describe('Request', () => {
         contrast: 0,
         dynamicLineart: true
       },
-      pipeline: 'test-pipeline'
+      pipeline: config.pipelines[0].description
     });
 
     assert.strictEqual(request.params.deviceId, 'epson2:libusb:001:029');
@@ -103,7 +104,7 @@ describe('Request', () => {
   it('scanimage-a8.txt', () => {
     const file = FileInfo.create('test/resource/scanimage-a8.txt');
     const device = Device.from(file.toText());
-    const context = new Context(config, [device]);
+    const context = new Context(config, [device], new UserOptions());
     const request = new Request(context).extend({
       params: {
         deviceId: 'umax1220u:libusb:001:004',
@@ -117,7 +118,7 @@ describe('Request', () => {
         contrast: 0,
         dynamicLineart: true
       },
-      pipeline: 'test-pipeline'
+      pipeline: config.pipelines[0].description
     });
 
     assert.strictEqual(request.params.deviceId, 'umax1220u:libusb:001:004');
@@ -135,7 +136,7 @@ describe('Request', () => {
   it('scanimage-a10.txt', () => {
     const file = FileInfo.create('test/resource/scanimage-a10.txt');
     const device = Device.from(file.toText());
-    const context = new Context(config, [device]);
+    const context = new Context(config, [device], new UserOptions());
     const request = new Request(context).extend({
       params: {
         top: -1,
@@ -148,7 +149,7 @@ describe('Request', () => {
         contrast: 0,
         dynamicLineart: true
       },
-      pipeline: 'test-pipeline'
+      pipeline: config.pipelines[0].description
     });
 
     assert.strictEqual(request.params.deviceId, 'epjitsu:libusb:001:003');

--- a/packages/server/test/scanimage-command.test.js
+++ b/packages/server/test/scanimage-command.test.js
@@ -4,6 +4,7 @@ const Context = require('../src/classes/context');
 const Device = require('../src/classes/device');
 const FileInfo = require('../src/classes/file-info');
 const Request = require('../src/classes/request');
+const UserOptions = require('../src/classes/user-options');
 
 const application = require('../src/application');
 const scanimageCommand = application.scanimageCommand();
@@ -68,7 +69,7 @@ describe('ScanimageCommand', () => {
   it('scanimage-a10.txt', () => {
     const file = FileInfo.create('test/resource/scanimage-a10.txt');
     const device = Device.from(file.toText());
-    const context = new Context(application.config(), [device]);
+    const context = new Context(application.config(), [device], new UserOptions());
     const request = new Request(context).extend({
       params: {
         mode: 'Color'


### PR DESCRIPTION
Issue #434

Added new `settings` property to `device` which contains `batchMode`, `pipeline` and `filters`. Each of those has `options` and `default` and these are respected by the UI.

See documentation for more details.

* Updated server and client to accommodate `device.settings` - this had various architectural impacts which have been resolved; such as:
  * UserOptions now taking a parameter to aid unit tests
  * Custom object merging for manually added devices
  * Injecting the settings themselves
* Added some assertions to the server `Request`
* Tidied up Vue scan component where computed properties not available
* Fixed zip thumbnail error