### PR TITLE
Use less CPU and RAM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ FROM node:16-bullseye-slim AS scanservjs-base
 RUN apt-get update \
   && apt-get install -yq \
     imagemagick \
+    img2pdf \
     sane \
     sane-utils \
     tesseract-ocr \

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ It supports any
 
 * SANE Scanner
 * Linux host (or VM with necessary pass-through e.g. USB)
-* Software sane-utils, ImageMagick, Tesseract (optional) and nodejs
+* Software sane-utils, ImageMagick, img2pdf, Tesseract (optional) and nodejs
 
 ## Documentation
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@
 
 ```shell
 # Install dependencies
-sudo apt-get install curl nodejs npm imagemagick sane-utils tesseract-ocr
+sudo apt-get install curl nodejs npm imagemagick img2pdf sane-utils tesseract-ocr
 
 # Ideally set the npm version
 sudo npm install npm@8.3.0 -g

--- a/docs/install.md
+++ b/docs/install.md
@@ -81,7 +81,7 @@ For more on problems installing an up to date nodejs on Debian which includes
 ```console
 curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
 sudo apt install -y nodejs
-sudo apt-get install npm sane-utils imagemagick
+sudo apt-get install npm sane-utils imagemagick img2pdf
 ```
 
 Debian calls the node binary "nodejs", which results in npm not being able to
@@ -96,4 +96,4 @@ for more details.
 ## Arch
 
 If you're using Arch, you probably don't need help but this worked a few years
-ago `sudo pacman -S nodejs npm sane-utils imagemagick curl`
+ago `sudo pacman -S nodejs npm sane-utils imagemagick img2pdf curl`

--- a/docs/sane.md
+++ b/docs/sane.md
@@ -1,10 +1,10 @@
-# SANE, imagemagick, scanners
+# SANE, imagemagick, img2pdf, scanners
 
 ## Install
 
 Just use your package manager.
 
-  * Debian / Ubuntu / Raspbian: `sudo apt install sane-utils imagemagick`
+  * Debian / Ubuntu / Raspbian: `sudo apt install sane-utils imagemagick img2pdf`
   * Arch: `sudo pacman -S sane`
 
 ## Validate SANE is working
@@ -137,7 +137,7 @@ then feel free to raise and issues or PR.
  * Type `lsusb` to check the scanner is attached
  * At the terminal type the following commands
     * `opkg update`
-    * `opkg install sane-frontends imagemagick sudo`
+    * `opkg install sane-frontends imagemagick img2pdf sudo`
  * Confirm installation typing...
     * `sane-find-scanner -q`
     * `scanimage -L`

--- a/packages/server/installer.sh
+++ b/packages/server/installer.sh
@@ -22,6 +22,7 @@ install() {
     nodejs \
     npm \
     imagemagick \
+    img2pdf \
     sane-utils \
     tesseract-ocr \
     tesseract-ocr-ara \
@@ -132,7 +133,7 @@ $ netstat -tulpn | grep :8080 --->
   $(netstat -tulpn | grep ":8080\s")
 
 Either
-* update the port in $location/config/config.local.js or 
+* update the port in $location/config/config.local.js or
 * Stop the other program
 
 After that you can just enable and start:
@@ -183,6 +184,7 @@ hard_uninstall() {
     npm \
     imagemagick \
     sane-utils \
+    img2pdf \
     tesseract-ocr
 }
 
@@ -217,7 +219,7 @@ scanservjs: https://github.com/sbs20/scanservjs
   Install runs through the following steps
 
     * run apt-get update
-    * install SANE, node and imagemagick dependencies
+    * install SANE, node, imagemagick and img2pdf dependencies
     * create the web application in /var/www/scanservjs
     * create a user and systemd service which is enabled and started
 

--- a/packages/server/src/classes/config.js
+++ b/packages/server/src/classes/config.js
@@ -118,7 +118,7 @@ module.exports = class Config {
         extension: 'jpg',
         description: 'JPG | @:pipeline.high-quality',
         commands: [
-          'convert @- -quality 92 scan-%04d.jpg',
+          'while read filename ; do convert -quality 92 $filename scan-$(date +%s.%N).jpg ; done',
           'ls scan-*.*'
         ]
       },
@@ -126,7 +126,7 @@ module.exports = class Config {
         extension: 'jpg',
         description: 'JPG | @:pipeline.medium-quality',
         commands: [
-          'convert @- -quality 75 scan-%04d.jpg',
+          'while read filename ; do convert -quality 75 $filename scan-$(date +%s.%N).jpg ; done',
           'ls scan-*.*'
         ]
       },
@@ -134,7 +134,7 @@ module.exports = class Config {
         extension: 'jpg',
         description: 'JPG | @:pipeline.low-quality',
         commands: [
-          'convert @- -quality 50 scan-%04d.jpg',
+          'while read filename ; do convert -quality 50 $filename scan-$(date +%s.%N).jpg ; done',
           'ls scan-*.*'
         ]
       },
@@ -142,7 +142,7 @@ module.exports = class Config {
         extension: 'png',
         description: 'PNG',
         commands: [
-          'convert @- -quality 75 scan-%04d.png',
+          'while read filename ; do convert -quality 75 $filename scan-$(date +%s.%N).png ; done',
           'ls scan-*.*'
         ]
       },
@@ -150,7 +150,7 @@ module.exports = class Config {
         extension: 'tif',
         description: 'TIF | @:pipeline.uncompressed',
         commands: [
-          'convert @- scan-0000.tif',
+          'while read filename ; do convert $filename scan-$(date +%s.%N).tif ; done',
           'ls scan-*.*'
         ]
       },
@@ -158,7 +158,7 @@ module.exports = class Config {
         extension: 'tif',
         description: 'TIF | @:pipeline.lzw-compressed',
         commands: [
-          'convert @- -compress lzw scan-0000.tif',
+          'while read filename ; do convert -compress lzw $filename scan-$(date +%s.%N).tif ; done',
           'ls scan-*.*'
         ]
       },
@@ -166,7 +166,7 @@ module.exports = class Config {
         extension: 'pdf',
         description: 'PDF (TIF | @:pipeline.uncompressed)',
         commands: [
-          'convert @- scan-0000.pdf',
+          'xargs img2pdf --output scan-0000.pdf',
           'ls scan-*.*'
         ]
       },
@@ -174,8 +174,8 @@ module.exports = class Config {
         extension: 'pdf',
         description: 'PDF (TIF | @:pipeline.lzw-compressed)',
         commands: [
-          'convert @- -compress lzw tmp-%04d.tif && ls tmp-*.tif',
-          'convert @- scan-0000.pdf',
+          'while read filename ; do convert -compress lzw $filename converted-$(date +%s.%N).tif ; done',
+          'img2pdf --output scan-0000.pdf $(ls -v converted-*.tif)',
           'ls scan-*.*'
         ]
       },
@@ -183,8 +183,8 @@ module.exports = class Config {
         extension: 'pdf',
         description: 'PDF (JPG | @:pipeline.high-quality)',
         commands: [
-          'convert @- -quality 92 tmp-%04d.jpg && ls tmp-*.jpg',
-          'convert @- scan-0000.pdf',
+          'while read filename ; do convert -quality 92 $filename converted-$(date +%s.%N).jpg ; done',
+          'img2pdf --output scan-0000.pdf $(ls -v *.jpg)',
           'ls scan-*.*'
         ]
       },
@@ -192,8 +192,8 @@ module.exports = class Config {
         extension: 'pdf',
         description: 'PDF (JPG | @:pipeline.medium-quality)',
         commands: [
-          'convert @- -quality 75 tmp-%04d.jpg && ls tmp-*.jpg',
-          'convert @- scan-0000.pdf',
+          'while read filename ; do convert -quality 75 $filename converted-$(date +%s.%N).jpg ; done',
+          'img2pdf --output scan-0000.pdf $(ls -v *.jpg)',
           'ls scan-*.*'
         ]
       },
@@ -201,8 +201,8 @@ module.exports = class Config {
         extension: 'pdf',
         description: 'PDF (JPG | @:pipeline.low-quality)',
         commands: [
-          'convert @- -quality 50 tmp-%04d.jpg && ls tmp-*.jpg',
-          'convert @- scan-0000.pdf',
+          'while read filename ; do convert -quality 50 $filename converted-$(date +%s.%N).jpg ; done',
+          'img2pdf --output scan-0000.pdf $(ls -v *.jpg)',
           'ls scan-*.*'
         ]
       },
@@ -211,7 +211,7 @@ module.exports = class Config {
         description: '@:pipeline.ocr | PDF (JPG | @:pipeline.high-quality)',
         get commands() {
           return [
-            'convert @- -quality 92 tmp-%d.jpg && ls tmp-*.jpg',
+            'while read filename ; do convert -quality 92 $filename tmp-$(date +%s.%N).jpg ; done  && ls tmp-*.jpg',
             `${config.tesseract} -l ${config.ocrLanguage} -c stream_filelist=true - - pdf > scan-0001.pdf`,
             'ls scan-*.*'
           ];

--- a/packages/server/src/scan-controller.js
+++ b/packages/server/src/scan-controller.js
@@ -89,7 +89,7 @@ class ScanController {
       files = (await this.listFiles()).filter(f => f.name.match(/f-\d{4}\.tif/));
     }
 
-    const stdin = files.map(f => f.name).join('\n');
+    const stdin = files.map(f => f.name).join('\n') + '\n';
     log.debug('Executing cmds:', this.pipeline.commands);
     const stdout = await Process.chain(this.pipeline.commands, stdin, { cwd: config.tempDirectory });
     let filenames = stdout.toString().split('\n').filter(f => f.length > 0);


### PR DESCRIPTION
Refs #537 .

This PR:
* uses img2pdf instead of imagemagick to create PDFs. This saves much CPU and RAM usage, because this merely "staples together" various JPG files, whereas imagemagick would load every JPG into memory, do some kind of transcoding _then_ writes
them to a PDF file.
* when image transcoding/compression is needed, it does this file by file, rather than "all files at once". This avoids imagemagick trying to load _all of them_ to memory before it converts them.

This makes some pipelines slightly faster to process, but this improves RAM usage a lot for most of them when multiple pages are scanned. On older Raspberry Pis, this fixes the "pipeline has stalled because RAM is full" issue.

Disclaimers:
* I'm not a JS developer, maybe there's a more idiomatic way to add a final newline in the first commit
* I have tested with my scanner and my Raspberry Pi. In case you have more scanners and more devices to test, feel free to do so :)

This only refs #537 and does not fix it, because there's still the "transcode every page when the next page is being scanned, instead of transcoding all of them at the end" improvement that could be done one day.

Thanks