### PR TITLE
Make `api-docs` a relative link

### DIFF
--- a/packages/client/src/components/About.vue
+++ b/packages/client/src/components/About.vue
@@ -13,7 +13,7 @@
 
     <div class="body-1 mb-4">
       {{ $t('about.api') }}
-      <a target="_blank" href="/api-docs">Swagger /api-docs</a>
+      <a target="_blank" href="api-docs">Swagger /api-docs</a>
     </div>
 
     <v-btn @click="showSystemInfo">{{ $t('about.system-info') }}</v-btn>


### PR DESCRIPTION
No associated issue. But this is to make it work with a reverse proxy with path translation.