### PR TITLE
Add Support for ALD Option

### DIFF
--- a/packages/server/src/classes/feature.js
+++ b/packages/server/src/classes/feature.js
@@ -36,6 +36,14 @@ module.exports = class Feature {
     this.interval = steps ? Number(steps[1]) : 1;
   }
 
+  asEnum() {
+    // Example: [=(yes|no)]
+    const match = /^\[=\((.*)\)\]$/.exec(this.parameters);
+    if (match !== null) {
+      this.options = match[1].split('|');
+    }
+  }
+
   asResolution() {
     if (this.parameters.indexOf('|') > -1) {
       this.options = splitNumbers(this.parameters, '|');
@@ -96,6 +104,10 @@ module.exports = class Feature {
         case '--brightness':
         case '--contrast':
           this.asLighting();
+          break;
+
+        case '--ald':
+          this.asEnum();
           break;
       }
     }

--- a/packages/server/src/classes/request.js
+++ b/packages/server/src/classes/request.js
@@ -98,6 +98,10 @@ module.exports = class Request {
         ? data.params.dynamicLineart
         : true;
     }
+    if ('--ald' in features) {
+      this.params.ald = data.params.ald || features['--ald'].default;
+      assertContains(features['--ald'].options, this.params.ald, 'Invalid --ald');
+    }
 
     log.trace(LogFormatter.format().full(this));
   }

--- a/packages/server/src/classes/scanimage-command.js
+++ b/packages/server/src/classes/scanimage-command.js
@@ -108,6 +108,9 @@ module.exports = class ScanimageCommand {
 
     cmdBuilder.arg('--format', params.format);
 
+    if ('ald' in params) {
+      cmdBuilder.arg(`--ald=${params.ald}`);
+    }
     if ('depth' in params) {
       cmdBuilder.arg('--depth', params.depth);
     }

--- a/packages/server/src/swagger.yml
+++ b/packages/server/src/swagger.yml
@@ -572,6 +572,9 @@ definitions:
       dynamicLineart:
         type: boolean
         example: false
+      ald:
+        type: string
+        example: 'yes'
     required:
       - deviceId
       - resolution

--- a/packages/server/test/device.test.js
+++ b/packages/server/test/device.test.js
@@ -34,6 +34,7 @@ describe('Device', () => {
     assert.strictEqual(device.features['--contrast'].limits[1], 100);
     assert.strictEqual(device.features['--contrast'].interval, 1);
     assert.strictEqual(device.features['--contrast'].default, 0);
+    assert.strictEqual(device.features['--ald'], undefined);
   });
 
   it('scanimage-a2.txt', () => {
@@ -60,6 +61,7 @@ describe('Device', () => {
     assert.strictEqual(device.features['-y'].default, 297.1);
     assert.strictEqual(device.features['--brightness'], undefined);
     assert.strictEqual(device.features['--contrast'], undefined);
+    assert.strictEqual(device.features['--ald'], undefined);
   });
 
   it('scanimage-a3.txt', () => {
@@ -88,6 +90,7 @@ describe('Device', () => {
     assert.strictEqual(device.features['--contrast'].limits[1], 50);
     assert.strictEqual(device.features['--contrast'].interval, 10);
     assert.strictEqual(device.features['--contrast'].default, 0);
+    assert.strictEqual(device.features['--ald'], undefined);
   });
 
   it('scanimage-a4.txt', () => {
@@ -111,6 +114,7 @@ describe('Device', () => {
     assert.strictEqual(device.features['-y'].limits[1], 297.1);
     assert.strictEqual(device.features['--brightness'], undefined);
     assert.strictEqual(device.features['--contrast'], undefined);
+    assert.strictEqual(device.features['--ald'], undefined);
   });
 
   it('scanimage-a5.txt', () => {
@@ -134,6 +138,7 @@ describe('Device', () => {
     assert.strictEqual(device.features['-y'].limits[1], 355.6);
     assert.strictEqual(device.features['--brightness'], undefined);
     assert.strictEqual(device.features['--contrast'], undefined);
+    assert.strictEqual(device.features['--ald'], undefined);
   });
 
   it('scanimage-a6.txt', () => {
@@ -157,6 +162,7 @@ describe('Device', () => {
     assert.strictEqual(device.features['-y'].limits[1], 355.6);
     assert.strictEqual(device.features['--brightness'], undefined);
     assert.strictEqual(device.features['--contrast'], undefined);
+    assert.strictEqual(device.features['--ald'], undefined);
   });
 
   it('scanimage-a8.txt', () => {
@@ -178,6 +184,7 @@ describe('Device', () => {
     assert.strictEqual(device.features['-y'].limits[0], 0);
     assert.strictEqual(device.features['-y'].limits[1], 298);
     assert.strictEqual(device.features['-y'].default, 298);
+    assert.strictEqual(device.features['--ald'], undefined);
   });
 
   it('scanimage-a9.txt', () => {
@@ -202,6 +209,7 @@ describe('Device', () => {
     assert.strictEqual(device.features['-y'].limits[0], 0);
     assert.strictEqual(device.features['-y'].limits[1], 297.1);
     assert.strictEqual(device.features['-y'].default, 297.1);
+    assert.strictEqual(device.features['--ald'], undefined);
   });
 
   it('scanimage-a10.txt', () => {
@@ -227,6 +235,7 @@ describe('Device', () => {
     assert.strictEqual(device.features['-t'].default, 0);
     assert.strictEqual(device.features['-t'].interval, 0.0211639);
     assert.strictEqual(device.features['-y'], undefined);
+    assert.strictEqual(device.features['--ald'], undefined);
   });
 
   it('scanimage-a11.txt', () => {
@@ -256,6 +265,35 @@ describe('Device', () => {
     assert.strictEqual(device.features['-y'].limits[0], 0);
     assert.strictEqual(device.features['-y'].limits[1], 431.8);
     assert.strictEqual(device.features['-y'].default, 431.8);
+    assert.strictEqual(device.features['--ald'], undefined);
+  });
+
+  it('scanimage-a12-adf.txt', () => {
+    const file = FileInfo.create('test/resource/scanimage-a12-adf.txt');
+    const device = Device.from(file.toText());
+
+    assert.strictEqual(device.id, 'net:<IP address>:fujitsu:fi-7260:1208958');
+    assert.deepStrictEqual(device.features['--source'].options, ['Flatbed', 'ADF Front', 'ADF Back', 'ADF Duplex']);
+    assert.strictEqual(device.features['--source'].default, 'ADF Front');
+    assert.deepStrictEqual(device.features['--mode'].options, ['Lineart', 'Halftone', 'Gray', 'Color']);
+    assert.strictEqual(device.features['--mode'].default, 'Lineart');
+    assert.deepStrictEqual(device.features['--ald'].options, ['yes', 'no']);
+    assert.strictEqual(device.features['--ald'].default, 'no');
+    assert.strictEqual(device.features['--ald'].meta, undefined);
+  });
+
+  it('scanimage-a12-flatbed.txt', () => {
+    const file = FileInfo.create('test/resource/scanimage-a12-flatbed.txt');
+    const device = Device.from(file.toText());
+
+    assert.strictEqual(device.id, 'net:<IP address>:fujitsu:fi-7260:1208958');
+    assert.deepStrictEqual(device.features['--source'].options, ['Flatbed', 'ADF Front', 'ADF Back', 'ADF Duplex']);
+    assert.strictEqual(device.features['--source'].default, 'Flatbed');
+    assert.deepStrictEqual(device.features['--mode'].options, ['Lineart', 'Halftone', 'Gray', 'Color']);
+    assert.strictEqual(device.features['--mode'].default, 'Lineart');
+    assert.deepStrictEqual(device.features['--ald'].options, ['yes', 'no']);
+    assert.strictEqual(device.features['--ald'].default, 'no');
+    assert.strictEqual(device.features['--ald'].meta, undefined);
   });
 
   it('scanimage-a13.txt', () => {
@@ -292,5 +330,47 @@ describe('Device', () => {
     assert.strictEqual(device.features['-y'].limits[0], 0);
     assert.strictEqual(device.features['-y'].limits[1], 296.9);
     assert.strictEqual(device.features['-y'].default, 296.9);
+    assert.strictEqual(device.features['--ald'], undefined);
   });
+
+  it('scanimage-a14.txt', () => {
+    const file = FileInfo.create('test/resource/scanimage-a14.txt');
+    const device = Device.from(file.toText());
+
+    assert.strictEqual(device.id, 'fujitsu:ScanSnap S1500:8176');
+    assert.deepStrictEqual(device.features['--mode'].options, ['Lineart', 'Halftone', 'Gray', 'Color']);
+    assert.strictEqual(device.features['--mode'].default, 'Lineart');
+    assert.deepStrictEqual(device.features['--source'].options, ['ADF Front', 'ADF Back', 'ADF Duplex']);
+    assert.strictEqual(device.features['--source'].default, 'ADF Front');
+    assert.deepStrictEqual(device.features['--resolution'].options, [50, 75, 150, 300, 600]);
+    assert.strictEqual(device.features['--resolution'].default, 600);
+    assert.strictEqual(device.features['--page-height'].limits[0], 0);
+    assert.strictEqual(device.features['--page-height'].limits[1], 876.6);
+    assert.strictEqual(device.features['--page-height'].default, 279.3);
+    assert.strictEqual(device.features['--page-width'].limits[0], 0);
+    assert.strictEqual(device.features['--page-width'].limits[1], 221.1);
+    assert.strictEqual(device.features['--page-width'].default, 215.8);
+    assert.strictEqual(device.features['-l'].limits[0], 0);
+    assert.strictEqual(device.features['-l'].limits[1], 215.8);
+    assert.strictEqual(device.features['-l'].default, 0);
+    assert.strictEqual(device.features['-t'].limits[0], 0);
+    assert.strictEqual(device.features['-t'].limits[1], 279.3);
+    assert.strictEqual(device.features['-t'].default, 0);
+    assert.strictEqual(device.features['-x'].limits[0], 0);
+    assert.strictEqual(device.features['-x'].limits[1], 215.8);
+    assert.strictEqual(device.features['-x'].default, 215.8);
+    assert.strictEqual(device.features['-y'].limits[0], 0);
+    assert.strictEqual(device.features['-y'].limits[1], 279.3);
+    assert.strictEqual(device.features['-y'].default, 279.3);
+    assert.deepStrictEqual(device.features['--ald'].options, ['yes', 'no']);
+    assert.strictEqual(device.features['--ald'].default, 'no');
+    assert.strictEqual(device.features['--ald'].meta, 'advanced');
+    assert.strictEqual(device.features['--brightness'].limits[0], -127);
+    assert.strictEqual(device.features['--brightness'].limits[1], 127);
+    assert.strictEqual(device.features['--brightness'].interval, 1);
+    assert.strictEqual(device.features['--brightness'].default, 0);
+    assert.strictEqual(device.features['--brightness'].meta, undefined);
+
+  });
+
 });

--- a/packages/server/test/resource/scanimage-a14.txt
+++ b/packages/server/test/resource/scanimage-a14.txt
@@ -1,0 +1,112 @@
+scanimage -A
+Output format is not set, using pnm as a default.
+
+All options specific to device `fujitsu:ScanSnap S1500:8176':
+  Standard:
+    --source ADF Front|ADF Back|ADF Duplex [ADF Front]
+        Selects the scan source (such as a document-feeder).
+    --mode Lineart|Halftone|Gray|Color [Lineart]
+        Selects the scan mode (e.g., lineart, monochrome, or color).
+    --resolution 50..600dpi (in steps of 1) [600]
+        Sets the resolution of the scanned image.
+  Geometry:
+    --page-width 0..221.121mm (in steps of 0.0211639) [215.872]
+        Specifies the width of the media.  Required for automatic centering of
+        sheet-fed scans.
+    --page-height 0..876.695mm (in steps of 0.0211639) [279.364]
+        Specifies the height of the media.
+    -l 0..215.872mm (in steps of 0.0211639) [0]
+        Top-left x position of scan area.
+    -t 0..279.364mm (in steps of 0.0211639) [0]
+        Top-left y position of scan area.
+    -x 0..215.872mm (in steps of 0.0211639) [215.872]
+        Width of scan-area.
+    -y 0..279.364mm (in steps of 0.0211639) [279.364]
+        Height of scan-area.
+  Enhancement:
+    --brightness -127..127 (in steps of 1) [0]
+        Controls the brightness of the acquired image.
+    --contrast -127..127 (in steps of 1) [0]
+        Controls the contrast of the acquired image.
+    --threshold 0..255 (in steps of 1) [0]
+        Select minimum-brightness to get a white point
+    --rif[=(yes|no)] [no]
+        Reverse image format
+    --ht-type Default|Dither|Diffusion [inactive]
+        Control type of halftone filter
+    --ht-pattern 0..3 (in steps of 1) [inactive]
+        Control pattern of halftone filter
+    --emphasis -128..127 (in steps of 1) [0]
+        Negative to smooth or positive to sharpen image
+    --variance 0..255 (in steps of 1) [0]
+        Set SDTC variance rate (sensitivity), 0 equals 127
+  Advanced:
+    --ald[=(yes|no)] [no] [advanced]
+        Scanner detects paper lower edge. May confuse some frontends.
+    --df-action Default|Continue|Stop [Default] [advanced]
+        Action following double feed error
+    --df-skew[=(yes|no)] [inactive]
+        Enable double feed error due to skew
+    --df-thickness[=(yes|no)] [inactive]
+        Enable double feed error due to paper thickness
+    --df-length[=(yes|no)] [inactive]
+        Enable double feed error due to paper length
+    --df-diff Default|10mm|15mm|20mm [inactive]
+        Difference in page length to trigger double feed error
+    --dropoutcolor Default|Red|Green|Blue [Default] [advanced]
+        One-pass scanners use only one color during gray or binary scanning,
+        useful for colored paper or ink
+    --buffermode Default|Off|On [Off] [advanced]
+        Request scanner to read pages quickly from ADF into internal memory
+    --sleeptimer 0..60 (in steps of 1) [0] [advanced]
+        Time in minutes until the internal power supply switches to sleep mode
+    --lowmemory[=(yes|no)] [no] [advanced]
+        Limit driver memory usage for use in embedded systems. Causes some
+        duplex transfers to alternate sides on each call to sane_read. Value of
+        option 'side' can be used to determine correct image. This option
+        should only be used with custom front-end software.
+    --side[=(yes|no)] [no] [read-only]
+        Tells which side (0=front, 1=back) of a duplex scan the next call to
+        sane_read will return.
+    --swdeskew[=(yes|no)] [no] [advanced]
+        Request driver to rotate skewed pages digitally.
+    --swdespeck 0..9 (in steps of 1) [0]
+        Maximum diameter of lone dots to remove from scan.
+    --swcrop[=(yes|no)] [no] [advanced]
+        Request driver to remove border from pages digitally.
+    --swskip 0..100% (in steps of 0.100006) [0]
+        Request driver to discard pages with low percentage of dark pixels
+  Sensors:
+    --top-edge[=(yes|no)] [no] [hardware]
+        Paper is pulled partly into ADF
+    --a3-paper[=(yes|no)] [no] [hardware]
+        A3 paper detected
+    --b4-paper[=(yes|no)] [no] [hardware]
+        B4 paper detected
+    --a4-paper[=(yes|no)] [no] [hardware]
+        A4 paper detected
+    --b5-paper[=(yes|no)] [no] [hardware]
+        B5 paper detected
+    --page-loaded[=(yes|no)] [no] [hardware]
+        Page loaded
+    --omr-df[=(yes|no)] [no] [hardware]
+        OMR or double feed detected
+    --cover-open[=(yes|no)] [no] [hardware]
+        Cover open
+    --power-save[=(yes|no)] [yes] [hardware]
+        Scanner in power saving mode
+    --email[=(yes|no)] [no] [hardware]
+        Email button
+    --manual-feed[=(yes|no)] [no] [hardware]
+        Manual feed selected
+    --scan[=(yes|no)] [no] [hardware]
+        Scan button
+    --function <int> [1] [hardware]
+        Function character on screen
+    --double-feed[=(yes|no)] [no] [hardware]
+        Double feed detected
+    --error-code <int> [0] [hardware]
+        Hardware error code
+    --skew-angle <int> [0] [hardware]
+        Requires black background for scanning
+

--- a/packages/server/test/scanimage-command.test.js
+++ b/packages/server/test/scanimage-command.test.js
@@ -80,4 +80,19 @@ describe('ScanimageCommand', () => {
     // eslint-disable-next-line quotes
     assert.strictEqual(command, `/usr/bin/scanimage -d epjitsu:libusb:001:003 --mode Color --source 'ADF Front' --resolution 300 --page-width 215.8 --page-height 292 -t 0 --format tiff --brightness 0 --contrast 0 -o data/temp/~tmp-scan-0-0001.tif`);
   });
+
+  it('scanimage-a14.txt', () => {
+    const file = FileInfo.create('test/resource/scanimage-a14.txt');
+    const device = Device.from(file.toText());
+    const context = new Context(application.config(), [device], new UserOptions());
+    const request = new Request(context, {
+      params: {
+        ald: 'yes'
+      }
+    });
+    const command = commandFor('1.1.1', request);
+    // eslint-disable-next-line quotes
+    assert.strictEqual(command, `/usr/bin/scanimage -d 'fujitsu:ScanSnap S1500:8176' --mode Lineart --source 'ADF Front' --resolution 600 --page-width 215.8 --page-height 279.3 -l 0 -t 0 -x 215.8 -y 279.3 --format tiff --ald=yes --brightness 0 -o data/temp/~tmp-scan-0-0001.tif`);
+  });
+
 });


### PR DESCRIPTION
Implement Parsing of (yes|no) options and add --ald to the command builder of scanimage. The feature is to turn on scanning when the automatic document feeder detects the start of the page.

--ald[=(yes|no)] [no] [advanced]'
     Scanner detects paper lower edge. May confuse some frontends.'