### PR TITLE
Allow locale configuration

### DIFF
--- a/packages/client/missing-translations.js
+++ b/packages/client/missing-translations.js
@@ -61,7 +61,7 @@ const locales = new class Locales {
   async children() {
     return (await this.all()).filter(l => l.key !== BASE);
   }
-}
+};
 
 async function main() {
   const en = await locales.base();

--- a/packages/client/src/classes/manifest-builder.js
+++ b/packages/client/src/classes/manifest-builder.js
@@ -1,0 +1,77 @@
+import colors from 'vuetify/lib/util/colors';
+
+export default class ManifestBuilder {
+  constructor() {
+  }
+
+  static create() {
+    return new ManifestBuilder();
+  }
+
+  withDark(dark) {
+    this.dark = dark;
+    return this;
+  }
+
+  withStorage(storage) {
+    this.storage = storage;
+    return this;
+  }
+
+  themeColor() {
+    const appColor = this.storage.settings.appColor;
+    switch (appColor) {
+      case 'accent-4':
+        return this.dark ? '#272727' : '#F5F5F5';
+      case 'deep-purple':
+        return colors['deepPurple']['base'];
+      case 'light-blue':
+        return colors['lightBlue']['base'];
+      case 'light-green':
+        return colors['lightGreen']['base'];
+      case 'deep-orange':
+        return colors['deepOrange']['base'];
+      default:
+        return colors[appColor]['base'];
+    }
+  }
+
+  build() {
+    return {
+      theme_color : this.themeColor(),
+      background_color : this.dark ? '#000000' : '#FFFFFF',
+      display : 'standalone',
+      scope : '/',
+      start_url : '/#/scan',
+      name : 'scanservjs',
+      short_name : 'scanservjs',
+      description : 'SANE scanner nodejs web ui',
+      icons : [
+        {
+          src : './icons/android-chrome-192x192.png',
+          sizes : '192x192',
+          type : 'image/png',
+          purpose : 'any'
+        },
+        {
+          src : './icons/android-chrome-512x512.png',
+          sizes : '512x512',
+          type : 'image/png',
+          purpose : 'any'
+        },
+        {
+          src : './icons/android-chrome-maskable-192x192.png',
+          sizes : '192x192',
+          type : 'image/png',
+          purpose : 'maskable'
+        },
+        {
+          src : './icons/android-chrome-maskable-512x512.png',
+          sizes : '512x512',
+          type : 'image/png',
+          purpose : 'maskable'
+        }
+      ]
+    };
+  }
+}

--- a/packages/client/src/classes/settings.js
+++ b/packages/client/src/classes/settings.js
@@ -10,7 +10,6 @@ export default class Settings {
     return {
       version: Constants.Version,
       theme: 'system',
-      locale: 'en',
       appColor: 'accent-4',
       showFilesAfterScan: true,
       thumbnails: {


### PR DESCRIPTION
Issue #583

Allows for better setting of the locale. The new behaviour is to select the first of the following:

* Query string param `locale`
* What is in saved settings
* Browser locale (`navigator.languages[0]`)
* English

In other words, the query string always wins so something like `http://scan.example.com:8080/?locale=fr` will display French.

Rationale:

* The UI loads prior to making any REST API calls - trying to get the settings from the config would result in janky reloading as the page loads, makes a call to the server and has to reload itself.
* If someone has saved settings then these should take precedence most of the time
* If someone has no settings at all and nothing in the URL then try and determine what to use from the browser. This should mean that most users get what they want most of the time the first time they use the app. (This relies on there being no local storage setting for the language. You can either delete these manually or load in a private browser to test)
* If the query string has the parameter then someone has decided that's what they want and it should always take precedence.