### PR TITLE
Fix for Dockerfile smell DL3015

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN npm run build
 # ==============================================================================
 FROM node:16-bullseye-slim AS scanservjs-base
 RUN apt-get update \
-  && apt-get install -yq \
+  && apt-get install --no-install-recommends -yq \
     imagemagick \
     sane \
     sane-utils \
@@ -119,7 +119,7 @@ FROM scanservjs-core
 # ==============================================================================
 FROM scanservjs-core AS scanservjs-hplip
 RUN apt-get update \
-  && apt-get install -yq libsane-hpaio \
+  && apt-get install --no-install-recommends -yq libsane-hpaio \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && echo hpaio >> /etc/sane.d/dll.conf


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3015](https://github.com/hadolint/hadolint/wiki/DL3015) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3015 occurs when the apt tool is used to install packages without the "--no-install-recommends" flag. This flag is recommended to be used to avoid installing additional packages not explicitly requested.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the "--no-install-recommends" flag is added to the apt-get install command.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance