### PR TITLE
Build workflow: ignore certain files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,8 @@ on:
     paths-ignore:
       - '.github/**'
       - 'docs/**'
-      - 'CODE_OF_CONDUCT.md'
       - 'LICENSE'
-      - 'README.md'
+      - '**/*.md'
       - 'Dockerfile'
       - 'run.sh'
 


### PR DESCRIPTION
Ignore all Markdown files.

No associated issue