### PR TITLE
Installer: Add net-tools (netstat command is needed)

### DIFF
--- a/packages/server/installer.sh
+++ b/packages/server/installer.sh
@@ -36,7 +36,8 @@ install() {
     tesseract-ocr-por \
     tesseract-ocr-rus \
     tesseract-ocr-tur \
-    tesseract-ocr-chi-sim
+    tesseract-ocr-chi-sim \
+    net-tools
 
   npm install npm@8.3.0 -g
 


### PR DESCRIPTION
Hi Sam! I found a little missing thing in your installer. Scanservjs uses `netstat` command (from `net-tools` package) but doesn't install required package in preparation phase of installation.