### PR TITLE
Additional contrast filters

### DIFF
--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -75,6 +75,8 @@
 
   "filter": {
     "auto-level": "مستوى ذاتي",
+    "auto-contrast": "Auto contrast",
+    "more-contrast": "More contrast",
     "threshold": "عتبة",
     "blur": "تمويه"
   },

--- a/packages/client/src/locales/cs.json
+++ b/packages/client/src/locales/cs.json
@@ -73,9 +73,11 @@
     "auto-collate-standard": "Automatický (Kompletovat 1, 3... 4, 2)",
     "auto-collate-reverse": "Automatický (Obrátit 1, 3... 2, 4)"
   },
-    
+
   "filter": {
     "auto-level": "Automatické zarovnání",
+    "auto-contrast": "Auto contrast",
+    "more-contrast": "More contrast",
     "threshold": "Práh",
     "blur": "Rozostření"
   },

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -74,6 +74,8 @@
 
   "filter": {
     "auto-level": "Automatische Farbjustierung",
+    "auto-contrast": "Automatische Kontrastjustierung",
+    "more-contrast": "Starker Kontrast",
     "threshold": "Schwellwert",
     "blur": "Weichzeichner"
   },

--- a/packages/client/src/locales/en-US.json
+++ b/packages/client/src/locales/en-US.json
@@ -78,6 +78,8 @@
 
   "filter": {
     "auto-level": "Auto level",
+    "auto-contrast": "Auto contrast",
+    "more-contrast": "More contrast",
     "threshold": "Threshold",
     "blur": "Blur"
   },

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -78,6 +78,8 @@
 
   "filter": {
     "auto-level": "Auto level",
+    "auto-contrast": "Auto contrast",
+    "more-contrast": "More contrast",
     "threshold": "Threshold",
     "blur": "Blur"
   },

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -61,7 +61,7 @@
     "files": "Ficheros",
     "settings": "Configuración",
     "about": "Acerca de",
-    "version": "Versión"  
+    "version": "Versión"
   },
 
   "batch-mode": {
@@ -71,9 +71,11 @@
     "auto-collate-standard": "Auto (ordenación 1, 3... 4, 2)",
     "auto-collate-reverse": "Auto (inversa 1, 3... 2, 4)"
   },
-  
+
   "filter": {
     "auto-level": "Autonivelar",
+    "auto-contrast": "Auto contrast",
+    "more-contrast": "More contrast",
     "threshold": "Umbral",
     "blur": "Difuminar"
   },
@@ -115,7 +117,7 @@
     "lzw-compressed": "Compresión LZW",
     "ocr": "OCR",
     "text-file": "Fichero de texto"
-  },  
+  },
 
   "paper-size": {
     "letter": "Letter (216 × 279 mm)",
@@ -153,7 +155,7 @@
     "message:no-devices": "No se encuentran dispositivos",
     "message:deleted-preview": "Vista previa eliminada",
     "message:turn-documents": "Girar documentos",
-    "message:preview-of-page": "Vista previa de página"  
+    "message:preview-of-page": "Vista previa de página"
   },
 
   "settings": {

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -73,7 +73,9 @@
   },
 
   "filter": {
-    "auto-level": "Automatique",
+    "auto-level": "Niveaux automatiques",
+    "auto-contrast": "Contraste automatique",
+    "more-contrast": "Augmenter le contraste",
     "threshold": "Seuil",
     "blur": "Flou"
   },

--- a/packages/client/src/locales/it.json
+++ b/packages/client/src/locales/it.json
@@ -73,9 +73,11 @@
     "auto-collate-standard": "Automatico (Fascicola 1, 3... 4, 2)",
     "auto-collate-reverse": "Automatico (Inverso 1, 3... 2, 4)"
   },
-  
+
   "filter": {
     "auto-level": "Livello automatico",
+    "auto-contrast": "Auto contrast",
+    "more-contrast": "More contrast",
     "threshold": "Soglia",
     "blur": "Sfocatura"
   },

--- a/packages/client/src/locales/nl.json
+++ b/packages/client/src/locales/nl.json
@@ -74,6 +74,8 @@
 
   "filter": {
     "auto-level": "Auto nivelleren",
+    "auto-contrast": "Auto contrast",
+    "more-contrast": "More contrast",
     "threshold": "Threshold",
     "blur": "Vervagen"
   },

--- a/packages/client/src/locales/pl.json
+++ b/packages/client/src/locales/pl.json
@@ -61,7 +61,7 @@
     "files": "Pliki",
     "settings": "Ustawienia",
     "about": "Informacje",
-    "version": "Wersja"  
+    "version": "Wersja"
   },
 
   "batch-mode": {
@@ -71,9 +71,11 @@
     "auto-collate-standard": "Automatyczny (kompletowane 1, 3... 4, 2)",
     "auto-collate-reverse": "Automatyczny (kolejność odwrotna 1, 3... 2, 4)"
   },
-    
+
   "filter": {
     "auto-level": "Automatyczne równanie",
+    "auto-contrast": "Auto contrast",
+    "more-contrast": "More contrast",
     "threshold": "Próg",
     "blur": "Rozmazanie"
   },
@@ -115,7 +117,7 @@
     "lzw-compressed": "Kompresja LZW",
     "ocr": "OCR",
     "text-file": "Plik tekstowy"
-  },  
+  },
 
   "paper-size": {
     "letter": "Letter",

--- a/packages/client/src/locales/pt-BR.json
+++ b/packages/client/src/locales/pt-BR.json
@@ -61,7 +61,7 @@
     "files": "Ficheros",
     "settings": "Configuração",
     "about": "Sobre",
-    "version": "Versão"  
+    "version": "Versão"
   },
 
   "batch-mode": {
@@ -71,9 +71,11 @@
     "auto-collate-standard": "Auto (ordenação 1, 3... 4, 2)",
     "auto-collate-reverse": "Auto (inversa 1, 3... 2, 4)"
   },
-  
+
   "filter": {
     "auto-level": "Autonivelar",
+    "auto-contrast": "Auto contrast",
+    "more-contrast": "More contrast",
     "threshold": "Nível",
     "blur": "Borrar"
   },
@@ -113,7 +115,7 @@
     "lzw-compressed": "Compressão LZW",
     "ocr": "OCR",
     "text-file": "Arquivo de texto"
-  },  
+  },
 
   "paper-size": {
     "letter": "Letter",
@@ -151,7 +153,7 @@
     "message:no-devices": "Nenhum dispositivo encontrado",
     "message:deleted-preview": "Visualização prévia excluída",
     "message:turn-documents": "Girar documentos",
-    "message:preview-of-page": "Visualização prévia de página"  
+    "message:preview-of-page": "Visualização prévia de página"
   },
 
   "settings": {

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -74,6 +74,8 @@
 
   "filter": {
     "auto-level": "Nivel automático",
+    "auto-contrast": "Auto contrast",
+    "more-contrast": "More contrast",
     "threshold": "Limiar",
     "blur": "Esbater"
   },

--- a/packages/client/src/locales/ru.json
+++ b/packages/client/src/locales/ru.json
@@ -71,9 +71,11 @@
     "auto-collate-standard": "Авто (Сопоставить 1, 3... 4, 2)",
     "auto-collate-reverse": "Авто (В обратном порядке 1, 3... 2, 4)"
   },
-  
+
   "filter": {
     "auto-level": "Автоматическое выравнивание",
+    "auto-contrast": "Auto contrast",
+    "more-contrast": "More contrast",
     "threshold": "Порог",
     "blur": "Размытие"
   },

--- a/packages/client/src/locales/sk.json
+++ b/packages/client/src/locales/sk.json
@@ -73,9 +73,11 @@
     "auto-collate-standard": "Automatický (V poradí 1, 3... ...4, 2)",
     "auto-collate-reverse": "Automatický (Reverzne 1, 3... 2, 4...)"
   },
-    
+
   "filter": {
     "auto-level": "Automatická úroveň",
+    "auto-contrast": "Auto contrast",
+    "more-contrast": "More contrast",
     "threshold": "Prah",
     "blur": "Rozostrenie"
   },

--- a/packages/client/src/locales/test.json
+++ b/packages/client/src/locales/test.json
@@ -66,7 +66,7 @@
     "files": "##FILES",
     "settings": "##SETTINGS",
     "about": "##ABOUT",
-    "version": "##VERSION"  
+    "version": "##VERSION"
   },
 
   "batch-mode": {
@@ -76,9 +76,11 @@
     "auto-collate-standard": "##COLLATE-STANDARD",
     "auto-collate-reverse": "##COLLATE-REVERSE"
   },
-  
+
   "filter": {
     "auto-level": "##SCAN.FILTERS:AUTO-LEVEL",
+    "auto-contrast": "##SCAN.FILTERS:AUTO-CONTRAST",
+    "more-contrast": "##SCAN.FILTERS:MORE-CONTRAST",
     "threshold": "##SCAN.FILTERS:THRESHOLD",
     "blur": "##SCAN.FILTERS:BLUR"
   },
@@ -164,7 +166,7 @@
     "message:no-devices": "##SCAN.NO-DEVICES",
     "message:deleted-preview": "##SCAN.DELETED-PREVIEW",
     "message:turn-documents": "##SCAN.TURN",
-    "message:preview-of-page": "##SCAN.PREVIEW-OF"  
+    "message:preview-of-page": "##SCAN.PREVIEW-OF"
   },
 
   "settings": {

--- a/packages/client/src/locales/tr.json
+++ b/packages/client/src/locales/tr.json
@@ -74,6 +74,8 @@
 
   "filter": {
     "auto-level": "Oto serviye",
+    "auto-contrast": "Auto contrast",
+    "more-contrast": "More contrast",
     "threshold": "Eşik",
     "blur": "Bulanıklık"
   },

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -59,7 +59,7 @@
     "files": "文件",
     "settings": "设置",
     "about": "关于",
-    "version": "版本"  
+    "version": "版本"
   },
 
   "batch-mode": {
@@ -69,9 +69,11 @@
     "auto-collate-standard": "自动 (标准校对 1, 3... 4, 2)",
     "auto-collate-reverse": "自动 (逆向校对 1, 3... 2, 4)"
   },
-  
+
   "filter": {
     "auto-level": "自动调整",
+    "auto-contrast": "Auto contrast",
+    "more-contrast": "More contrast",
     "threshold": "阈值",
     "blur": "模糊"
   },
@@ -112,7 +114,7 @@
     "lzw-compressed": "LZW 压缩",
     "ocr": "OCR文字识别",
     "text-file": "文本文档"
-  },  
+  },
 
   "paper-size": {
     "letter": "Letter",
@@ -150,7 +152,7 @@
     "message:no-devices": "未找到设备",
     "message:deleted-preview": "已清除预览",
     "message:turn-documents": "旋转文件",
-    "message:preview-of-page": "页面预览"  
+    "message:preview-of-page": "页面预览"
   },
 
   "settings": {

--- a/packages/server/src/classes/config.js
+++ b/packages/server/src/classes/config.js
@@ -71,6 +71,10 @@ module.exports = class Config {
 
       filters: [
         {
+          description: 'filter.auto-constrast',
+          params: '-auto-contrast'
+        },
+        {
           description: 'filter.auto-level',
           params: '-auto-level'
         },
@@ -81,6 +85,10 @@ module.exports = class Config {
         {
           description: 'filter.blur',
           params: '-blur 1'
+        },
+        {
+          description: 'filter.more-constrast',
+          params: '-level 90%,10%'
         }
       ],
 

--- a/packages/server/test/context.test.js
+++ b/packages/server/test/context.test.js
@@ -43,9 +43,11 @@ describe('Context', () => {
       },
       filters: {
         options: [
+          'filter.auto-constrast',
           'filter.auto-level',
           'filter.threshold',
-          'filter.blur'
+          'filter.blur',
+          'filter.more-constrast'
         ],
         default: []
       },
@@ -204,9 +206,11 @@ describe('Context', () => {
       },
       filters: {
         options: [
+          'filter.auto-constrast',
           'filter.auto-level',
           'filter.threshold',
-          'filter.blur'
+          'filter.blur',
+          'filter.more-constrast'
         ],
         default: []
       },


### PR DESCRIPTION
Added a filter to increase contrast.

On my printer (a Canon Pixma, fwiw), default scan settings lead to "washed out" images, and increasing the contrast generates better scans.
In my case, the `-contrast` imagemagick setting was not that great (even when doubled for more effect). That's why I came up with this half-custom `-level 10%,90%` command. It now works great, at least for B/W text documents.
For the sake of completeness, I have added both filters in this MR. Not sure whether you want to provide both to all users, or if you find it confusing, in which case I'll let you choose the one to provide to all your users!

I have included translations to languages I know, but I'm not a native German speaker.