### PR TITLE
Update base image to Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ RUN npm run build
 
 # Sane image
 #
-# This is the minimum bullseye/node/sane image required which is used elsewhere.
+# This is the minimum bookworm/node/sane image required which is used elsewhere.
 # ==============================================================================
-FROM node:16-bullseye-slim AS scanservjs-base
+FROM node:16-bookworm-slim AS scanservjs-base
 RUN apt-get update \
   && apt-get install -yq \
     imagemagick \


### PR DESCRIPTION
Debian Bullseye uses sane 1.0.31, while Bookworm uses 1.2.1.

Numerous scanners have had support added, including the [ScanSnap ix1600 in  version 1.1.1](https://gitlab.com/sane-project/backends/-/issues/435).


[Debian Versions](https://packages.debian.org/search?keywords=sane-utils)