### PR TITLE
improve system endpoint

### DIFF
--- a/packages/server/src/classes/system.js
+++ b/packages/server/src/classes/system.js
@@ -1,11 +1,17 @@
 const os = require('os');
+const fs = require('fs/promises');
 const Process = require('./process');
+
+// Detect npm version and container type and cache them here
+const npmVersion = getNpmVersion();
+const containerType = detectContainerType();
 
 module.exports = class System {
   /**
    * @returns {Promise.<SystemInfo>}
    */
   async info() {
+    const container = await containerType;
     const info = {
       os: {
         arch: os.arch(),
@@ -15,11 +21,9 @@ module.exports = class System {
         type: os.type()
       },
       node: process.version,
-      npm: (await Process.spawn('npm -v')).toString().trim(),
-      docker: (await Process.spawn(
-        'grep -s \'docker\\|lxc\' /proc/1/cgroup',
-        undefined,
-        { ignoreErrors: true } )).length > 0
+      npm: await npmVersion,
+      docker: container === "docker",
+      containerType: container,
     };
 
     try {
@@ -31,3 +35,44 @@ module.exports = class System {
     return info;
   }
 };
+
+/**
+ * @returns {Promise<string | null>} The detected npm version, or null, if detection failed.
+ */
+async function getNpmVersion() {
+  try {
+    const proc = await Process.spawn('npm -v');
+    return proc.toString().trim();
+  } catch (error) {
+    console.error("Failed to determine npm version", error);
+    return null;
+  }
+}
+
+/**
+ * @returns {Promise<'docker' | 'podman' | 'systemd-nspawn' | null>} The used container technology, or null if no container was detected.
+ */
+async function detectContainerType() {
+  try {
+    // Detect docker by the /.dockerenv file
+    await fs.stat('/.dockerenv');
+    return 'docker';
+  } catch (_) {}
+
+  try {
+    // Detect podman by the /run/.containerenv file
+    await fs.stat('/run/.containerenv');
+    return 'podman';
+  } catch (_) {}
+
+  try {
+    // Detect systemd-nspawn by the /run/host/container-manager file
+    const manager = await fs.readFile("/run/host/container-manager", 'utf-8');
+    if (manager === 'systemd-nspawn') {
+      return 'systemd-nspawn';
+    }
+  } catch (_) {}
+
+  return null;
+}
+


### PR DESCRIPTION
This PR improves the /system endpoint to not execute 2 processes on every request, which is pretty resource heavy.
Instead it reads the npm version on startup, and uses the cached value afterwards.

I also fixed the docker detection, as it did use a method which didn't work anymore.

It also detects now if it's running inside a podman or systemd-nspawn container in addition to docker.
I left the docker field untouched for backwards compatibility and added a new field in /system which contains the
containerization technology or `null` if none is detected.

