### PR TITLE
Additional contrast filters (#617)

### DIFF
--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -74,6 +74,8 @@
 
   "filter": {
     "auto-level": "Automatische Farbjustierung",
+    "auto-contrast": "Automatische Kontrastjustierung",
+    "more-contrast": "Starker Kontrast",
     "threshold": "Schwellwert",
     "blur": "Weichzeichner"
   },

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -78,6 +78,8 @@
 
   "filter": {
     "auto-level": "Auto level",
+    "auto-contrast": "Auto contrast",
+    "more-contrast": "More contrast",
     "threshold": "Threshold",
     "blur": "Blur"
   },

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -73,7 +73,9 @@
   },
 
   "filter": {
-    "auto-level": "Automatique",
+    "auto-level": "Niveaux automatiques",
+    "auto-contrast": "Contraste automatique",
+    "more-contrast": "Augmenter le contraste",
     "threshold": "Seuil",
     "blur": "Flou"
   },

--- a/packages/client/src/locales/test.json
+++ b/packages/client/src/locales/test.json
@@ -66,7 +66,7 @@
     "files": "##FILES",
     "settings": "##SETTINGS",
     "about": "##ABOUT",
-    "version": "##VERSION"  
+    "version": "##VERSION"
   },
 
   "batch-mode": {
@@ -76,9 +76,11 @@
     "auto-collate-standard": "##COLLATE-STANDARD",
     "auto-collate-reverse": "##COLLATE-REVERSE"
   },
-  
+
   "filter": {
     "auto-level": "##SCAN.FILTERS:AUTO-LEVEL",
+    "auto-contrast": "##SCAN.FILTERS:AUTO-CONTRAST",
+    "more-contrast": "##SCAN.FILTERS:MORE-CONTRAST",
     "threshold": "##SCAN.FILTERS:THRESHOLD",
     "blur": "##SCAN.FILTERS:BLUR"
   },
@@ -164,7 +166,7 @@
     "message:no-devices": "##SCAN.NO-DEVICES",
     "message:deleted-preview": "##SCAN.DELETED-PREVIEW",
     "message:turn-documents": "##SCAN.TURN",
-    "message:preview-of-page": "##SCAN.PREVIEW-OF"  
+    "message:preview-of-page": "##SCAN.PREVIEW-OF"
   },
 
   "settings": {

--- a/packages/server/src/classes/config.js
+++ b/packages/server/src/classes/config.js
@@ -71,6 +71,10 @@ module.exports = class Config {
 
       filters: [
         {
+          description: 'filter.auto-constrast',
+          params: '-auto-contrast'
+        },
+        {
           description: 'filter.auto-level',
           params: '-auto-level'
         },
@@ -81,6 +85,10 @@ module.exports = class Config {
         {
           description: 'filter.blur',
           params: '-blur 1'
+        },
+        {
+          description: 'filter.more-constrast',
+          params: '-level 90%,10%'
         }
       ],
 

--- a/packages/server/test/context.test.js
+++ b/packages/server/test/context.test.js
@@ -43,9 +43,11 @@ describe('Context', () => {
       },
       filters: {
         options: [
+          'filter.auto-constrast',
           'filter.auto-level',
           'filter.threshold',
-          'filter.blur'
+          'filter.blur',
+          'filter.more-constrast'
         ],
         default: []
       },
@@ -204,9 +206,11 @@ describe('Context', () => {
       },
       filters: {
         options: [
+          'filter.auto-constrast',
           'filter.auto-level',
           'filter.threshold',
-          'filter.blur'
+          'filter.blur',
+          'filter.more-constrast'
         ],
         default: []
       },


### PR DESCRIPTION
Added a filter to increase contrast.

On my printer (a Canon Pixma, fwiw), default scan settings lead to "washed out" images, and increasing the contrast generates better scans. In my case, the `-contrast` imagemagick setting was not that great (even when doubled for more effect). That's why I came up with this half-custom `-level 10%,90%` command. It now works great, at least for B/W text documents.
For the sake of completeness, I have added both filters in this MR. Not sure whether you want to provide both to all users, or if you find it confusing, in which case I'll let you choose the one to provide to all your users!

I have included translations to languages I know, but I'm not a native German speaker.

---------