### PR TITLE
Added thumbnail caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ dist
 **/server/config/devices.json
 **/server/data/output/*
 **/server/data/temp/*
+**/server/data/thumbnail/*
 **/server/data/preview/*.tif
 **/scan*.jpg
 **/config.local.js

--- a/packages/server/src/classes/config.js
+++ b/packages/server/src/classes/config.js
@@ -48,6 +48,7 @@ module.exports = class Config {
 
       devicesPath: './config/devices.json',
       outputDirectory: 'data/output',
+      thumbnailDirectory: 'data/thumbnail',
       previewDirectory: 'data/preview',
       tempDirectory: 'data/temp',
 

--- a/packages/server/src/configure.js
+++ b/packages/server/src/configure.js
@@ -64,6 +64,7 @@ function initialize(rootPath) {
     Object.assign(config, {
       devicesPath: rootPath + config.devicesPath,
       outputDirectory: rootPath + config.outputDirectory,
+      thumbnailDirectory: rootPath + config.thumbnailDirectory,
       previewDirectory: rootPath + config.previewDirectory,
       tempDirectory: rootPath + config.tempDirectory
     });
@@ -71,6 +72,7 @@ function initialize(rootPath) {
 
   try {
     fs.mkdirSync(config.outputDirectory, { recursive: true });
+    fs.mkdirSync(config.thumbnailDirectory, { recursive: true });
     fs.mkdirSync(config.tempDirectory, { recursive: true });
   } catch (exception) {
     log.warn(`Error ensuring output and temp directories exist: ${exception}`);
@@ -204,6 +206,10 @@ function configure(app, rootPath) {
       const newName = req.body.newName;
       await FileInfo.unsafe(config.outputDirectory, name)
         .rename(newName);
+      const thumbnail = FileInfo.unsafe(config.thumbnailDirectory, name);
+      if (thumbnail.exists()) {
+        thumbnail.rename(newName);
+      }
       res.send('200');
     } catch (error) {
       sendError(res, 500, error);

--- a/packages/server/src/types.js
+++ b/packages/server/src/types.js
@@ -71,6 +71,7 @@
  * @property {string} tesseract
  * @property {string} devicesPath
  * @property {string} outputDirectory
+ * @property {string} thumbnailDirectory
  * @property {string} previewDirectory
  * @property {string} tempDirectory
  * @property {number} previewResolution


### PR DESCRIPTION
This pull request adds thumbnail caching, which is very much needed for low power devices such as the raspberry pi.

The thumbnail is generated only when requested and will be deleted when the file is deleted.

Closes #433
Builds on original implementation in #592 