### PR TITLE
Update api paths

### DIFF
--- a/packages/client/src/components/About.vue
+++ b/packages/client/src/components/About.vue
@@ -57,7 +57,7 @@ export default {
 
     showSystemInfo() {
       this.$emit('mask', 1);
-      Common.fetch('system').then(data => {
+      Common.fetch('api/v1/system').then(data => {
         this.systemInfoDialog = true;
         this.systemInfo = data;
         this.$emit('mask', -1);

--- a/packages/client/src/components/Files.vue
+++ b/packages/client/src/components/Files.vue
@@ -58,7 +58,7 @@
     </template>
 
     <template v-if="thumbnails.show" #[`item.thumb`]="{ item }">
-      <v-img :src="`./files/${item.columns.name}/thumbnail`"
+      <v-img :src="`api/v1/files/${item.columns.name}/thumbnail`"
         width="128"
         :max-height="thumbnails.size" :max-width="thumbnails.size"
         :contain="true" />
@@ -174,7 +174,7 @@ export default {
   methods: {
     actionList() {
       this.$emit('mask', 1);
-      Common.fetch('context').then(context => {
+      Common.fetch('api/v1/context').then(context => {
         this.actions = context.actions;
         this.$emit('mask', -1);
       }).catch(error => {
@@ -185,7 +185,7 @@ export default {
 
     fileList() {
       this.$emit('mask', 1);
-      Common.fetch('files').then(files => {
+      Common.fetch('api/v1/files').then(files => {
         this.files = files;
         this.$emit('mask', -1);
       }).catch(error => {
@@ -196,7 +196,7 @@ export default {
 
     fileRemove(file) {
       this.$emit('mask', 1);
-      Common.fetch(`files/${file.name}`, {
+      Common.fetch(`api/v1/files/${file.name}`, {
         method: 'DELETE'
       }).then(data => {
         this.$emit('notify', {type: 'i', message: `${this.$t('files.message:deleted', [data.name])}`});
@@ -217,7 +217,7 @@ export default {
 
     renameFileConfirm() {
       this.$emit('mask', 1);
-      Common.fetch(`files/${this.editedItem.name}`, {
+      Common.fetch(`api/v1/files/${this.editedItem.name}`, {
         method: 'PUT',
         headers: {
           'Accept': 'application/json',
@@ -250,7 +250,7 @@ export default {
         refresh = true;
         const name = this.selectedFiles[0].name;
         try {
-          await Common.fetch(`files/${name}`, {method: 'DELETE'});
+          await Common.fetch(`api/v1/files/${name}`, {method: 'DELETE'});
           this.$emit('notify', {type: 'i', message: `${this.$t('files.message:deleted', [name])}`});
         } catch (error) {
           this.$emit('notify', {type: 'e', message: error});
@@ -269,7 +269,7 @@ export default {
         refresh = true;
         const filename = this.selectedFiles[0].name;
         try {
-          await Common.fetch(`files/${filename}/actions/${actionName}`, {method: 'POST'});
+          await Common.fetch(`api/v1/files/${filename}/actions/${actionName}`, {method: 'POST'});
           this.$emit('notify', {type: 'i', message: `${this.$t('files.message:action', [actionName, filename])}`});
         } catch (error) {
           this.$emit('notify', {type: 'e', message: error});
@@ -283,7 +283,7 @@ export default {
     },
 
     open(file) {
-      window.location.href = `files/${file.name}`;
+      window.location.href = `api/v1/files/${file.name}`;
     },
 
     selectToggle(value) {

--- a/packages/client/src/components/Scan.vue
+++ b/packages/client/src/components/Scan.vue
@@ -362,7 +362,7 @@ export default {
 
       let data = Common.clone(this.request);
 
-      this._fetch('preview', {
+      this._fetch('api/v1/preview', {
         method: 'POST',
         body: JSON.stringify(data),
         headers: {
@@ -383,7 +383,7 @@ export default {
 
     deletePreview() {
       this.mask(1);
-      Common.fetch('preview', {
+      Common.fetch('api/v1/preview', {
         method: 'DELETE'
       }).then(() => {
         this.notify({ type: 'i', message: this.$t('scan.message:deleted-preview') });
@@ -489,7 +489,7 @@ export default {
         this.notify({ type: 'i', message: this.$t('scan.message:loading-devices') });
       }, 250);
 
-      return this._fetch('context').then(context => {
+      return this._fetch('api/v1/context').then(context => {
         window.clearTimeout(timer);
 
         if (context.devices && context.devices.length > 0) {
@@ -508,7 +508,7 @@ export default {
     },
 
     deviceRefresh() {
-      this._fetch('context', {
+      this._fetch('api/v1/context', {
         method: 'DELETE'
       }).then(() => {
         this.readContext();
@@ -517,7 +517,7 @@ export default {
 
     readPreview() {
       // Gets the preview image as a base64 encoded jpg and updates the UI
-      const uri = 'preview?' + new URLSearchParams(
+      const uri = 'api/v1/preview?' + new URLSearchParams(
         this.request.filters.map(e => ['filter', e]));
 
       this._fetch(uri, {
@@ -551,7 +551,7 @@ export default {
       }
 
       const data = Common.clone(this.request);
-      this._fetch('scan', {
+      this._fetch('api/v1/scan', {
         method: 'POST',
         body: JSON.stringify(data),
         headers: {

--- a/packages/client/src/components/Settings.vue
+++ b/packages/client/src/components/Settings.vue
@@ -159,7 +159,7 @@ export default {
 
     reset() {
       this.$emit('mask', 1);
-      Common.fetch('context', {
+      Common.fetch('api/v1/context', {
         method: 'DELETE'
       }).then(() => {
         this.$emit('mask', -1);

--- a/packages/client/vite.config.js
+++ b/packages/client/vite.config.js
@@ -8,12 +8,8 @@ import packageJson from './package.json'
 export default defineConfig({
   server: {
     proxy: {
+      '/api': 'http://localhost:8080',
       '/api-docs': 'http://localhost:8080',
-      '/context': 'http://localhost:8080',
-      '/files': 'http://localhost:8080',
-      '/preview': 'http://localhost:8080',
-      '/scan': 'http://localhost:8080',
-      '/system': 'http://localhost:8080',
     }
   },
   plugins: [

--- a/packages/server/src/express-configurer.js
+++ b/packages/server/src/express-configurer.js
@@ -60,7 +60,7 @@ function formatForLog(req) {
 const EndpointSpecs = [
   {
     method: 'delete',
-    path: '/context',
+    path: '/api/v1/context',
     callback: async (req, res) => {
       api.deleteContext();
       res.send({});
@@ -68,17 +68,17 @@ const EndpointSpecs = [
   },
   {
     method: 'get',
-    path: '/context',
+    path: '/api/v1/context',
     callback: async (req, res) => res.send(await api.readContext())
   },
   {
     method: 'get',
-    path: '/files',
+    path: '/api/v1/files',
     callback: async (req, res) => res.send(await api.fileList())
   },
   {
     method: 'post',
-    path: /\/files\/([^/]+)\/actions\/([^/]+)/,
+    path: /\/api\/v1\/files\/([^/]+)\/actions\/([^/]+)/,
     callback: async (req, res) => {
       const fileName = req.params[0];
       const actionName = req.params[1];
@@ -88,7 +88,7 @@ const EndpointSpecs = [
   },
   {
     method: 'get',
-    path: /\/files\/([^/]+)\/thumbnail/,
+    path: /\/api\/v1\/files\/([^/]+)\/thumbnail/,
     callback: async (req, res) => {
       const name = req.params[0];
       const buffer = await api.readThumbnail(name);
@@ -98,7 +98,7 @@ const EndpointSpecs = [
   },
   {
     method: 'get',
-    path: /\/files\/([^/]+)/,
+    path: /\/api\/v1\/files\/([^/]+)/,
     callback: async (req, res) => {
       const name = req.params[0];
       const file = FileInfo.unsafe(config.outputDirectory, name);
@@ -107,12 +107,12 @@ const EndpointSpecs = [
   },
   {
     method: 'delete',
-    path: '/files/*',
+    path: '/api/v1/files/*',
     callback: async (req, res) => res.send(api.fileDelete(req.params[0]))
   },
   {
     method: 'put',
-    path: '/files/*',
+    path: '/api/v1/files/*',
     callback: async (req, res) => {
       const name = req.params[0];
       const newName = req.body.newName;
@@ -126,7 +126,7 @@ const EndpointSpecs = [
   },
   {
     method: 'get',
-    path: '/preview',
+    path: '/api/v1/preview',
     callback: async (req, res) => {
       const buffer = await api.readPreview(req.query.filter);
       res.send({
@@ -136,22 +136,22 @@ const EndpointSpecs = [
   },
   {
     method: 'delete',
-    path: '/preview',
+    path: '/api/v1/preview',
     callback: async (req, res) => res.send(api.deletePreview())
   },
   {
     method: 'post',
-    path: '/preview',
+    path: '/api/v1/preview',
     callback: async (req, res) => res.send(await api.createPreview(req.body))
   },
   {
     method: 'post',
-    path: '/scan',
+    path: '/api/v1/scan',
     callback: async (req, res) => res.send(await api.scan(req.body))
   },
   {
     method: 'get',
-    path: '/system',
+    path: '/api/v1/system',
     callback: async (req, res) => res.send(await api.readSystem())
   }
 ];

--- a/packages/server/src/swagger.yml
+++ b/packages/server/src/swagger.yml
@@ -1,5 +1,5 @@
 paths:
-  /context:
+  /api/v1/context:
     delete:
       summary: Deletes cached context
       description: |
@@ -30,7 +30,7 @@ paths:
               schema:
                 $ref: '#/definitions/Context'
 
-  /files:
+  /api/v1/files:
     get:
       summary: List all scanned files
       description: |
@@ -47,7 +47,7 @@ paths:
                 items:
                   $ref: '#/definitions/FileInfo'
 
-  /files/{filename}:
+  /api/v1/files/{filename}:
     delete:
       summary: Deletes a scanned file
       description: |
@@ -121,7 +121,7 @@ paths:
         '200':
           description: OK
 
-  /files/{filename}/thumbnail:
+  /api/v1/files/{filename}/thumbnail:
     get:
       summary: Gets an image thumbnail
       description: |
@@ -142,7 +142,7 @@ paths:
         '200':
           description: OK
 
-  /files/{filename}/actions/{actionName}:
+  /api/v1/files/{filename}/actions/{actionName}:
     post:
       summary: Performs an action on a file
       description: |
@@ -167,7 +167,7 @@ paths:
         '200':
           description: OK
 
-  /preview:
+  /api/v1/preview:
     delete:
       summary: Deletes the currently stored preview
       description: |
@@ -230,7 +230,7 @@ paths:
                 type: object
                 example: {}
 
-  /scan:
+  /api/v1/scan:
     post:
       summary: Create a scan
       description: |
@@ -257,7 +257,7 @@ paths:
               schema:
                 $ref: '#/definitions/ScanResponse'
 
-  /system:
+  /api/v1/system:
     get:
       summary: Gets host system information
       description: |


### PR DESCRIPTION
This is a breaking change, but an important one because it makes all server paths more easily identifiable as they're prefixed with `api/v1/` - with the exception of the swagger stuff.