### PR TITLE
Fix `--batch=format` argument

### DIFF
--- a/app-server/src/classes/command-builder.js
+++ b/app-server/src/classes/command-builder.js
@@ -40,6 +40,30 @@ module.exports = class CommandBuilder {
   }
 
   /**
+   * Use for arguments requiring key=value. Using `arg(...)` doesn't work:
+   *
+   * ```js
+   *   .arg('-key', 'value') // becomes "-key value"
+   *   .arg('-key=value') // becomes "'-key=value'"
+   * ```
+   *
+   * Both of these results are incorrect and fail to work.
+   *
+   * This method provides a solution so that
+   *
+   * ```js
+   *   .argPair('-key', 'value') // becomes "-key='value'"
+   * ```
+   * @param {string} key
+   * @param {string} value
+   */
+  argPair(key, value) {
+    const arg = `${this._format(key)}=${this._format(value)}`;
+    this.args.push(arg);
+    return this;
+  }
+
+  /**
    * @param {string} operator
    * @returns {CmdBuilder}
    */

--- a/app-server/src/classes/scanimage-command.js
+++ b/app-server/src/classes/scanimage-command.js
@@ -123,7 +123,7 @@ module.exports = class ScanimageCommand {
     }
     if ([Constants.BATCH_AUTO, Constants.BATCH_COLLATE_STANDARD, Constants.BATCH_COLLATE_REVERSE].includes(request.batch)) {
       const pattern = `${this.config.tempDirectory}/${Constants.TEMP_FILESTEM}-${request.index}-%04d.tif`;
-      cmdBuilder.arg(`--batch=${pattern}`);
+      cmdBuilder.argPair('--batch', pattern);
     } else {
       const outputFile = 'isPreview' in params && params.isPreview
         ? `${this.config.previewDirectory}/preview.tif`

--- a/app-server/test/command-builder.test.js
+++ b/app-server/test/command-builder.test.js
@@ -110,4 +110,30 @@ describe('CommandBuilder', () => {
       () => new CommandBuilder('echo').redirect(['invalid']).build(),
       /Error: Invalid argument.*/);
   });
+
+  it('command-argPair-simple', async () => {
+    assert.strictEqual(
+      new CommandBuilder('echo').argPair('--batch', 'path.jpg').build(),
+      'echo --batch=path.jpg');
+  });
+
+  it('command-argPair-escape', async () => {
+    assert.strictEqual(
+      new CommandBuilder('echo').argPair('--batch', '/path/file-%04d.jpg').build(),
+      // eslint-disable-next-line quotes
+      `echo --batch='/path/file-%04d.jpg'`);
+  });
+
+  it('command-argPair-escape-dblquote', async () => {
+    assert.strictEqual(
+      new CommandBuilder('echo').argPair('--batch', '/path/file-".jpg').build(),
+      // eslint-disable-next-line quotes
+      `echo --batch='/path/file-".jpg'`);
+  });
+
+  it('command-argPair-bad', async () => {
+    assert.throws(
+      () => new CommandBuilder('echo').argPair('--batch', 'file-\'.jpg').build(),
+      /Error: Argument must not contain.*/);
+  });
 });

--- a/app-server/test/scanimage-command.test.js
+++ b/app-server/test/scanimage-command.test.js
@@ -95,4 +95,19 @@ describe('ScanimageCommand', () => {
     assert.strictEqual(command, `/usr/bin/scanimage -d 'fujitsu:ScanSnap S1500:8176' --source 'ADF Front' --mode Lineart --resolution 600 --page-width 215.8 --page-height 279.3 -l 0 -t 0 -x 215.8 -y 279.3 --format tiff --ald=yes --brightness 0 -o data/temp/~tmp-scan-0-0001.tif`);
   });
 
+  it('scanimage-batch.txt', () => {
+    const file = FileInfo.create('test/resource/scanimage-a5.txt');
+    const device = Device.from(file.toText());
+    const context = new Context(application.config(), [device], new UserOptions());
+    const request = new Request(context, {
+      params: {
+        source: 'Automatic Document Feeder'
+      },
+      batch: 'auto'
+    });
+    const command = commandFor('1.1.1', request);
+    // eslint-disable-next-line quotes
+    assert.strictEqual(command, `/usr/bin/scanimage -d 'pixma:04A91766_004AE4' --source 'Automatic Document Feeder' --mode Color --resolution 75 -l 0 -t 0 -x 216 -y 355.6 --format tiff --batch='data/temp/~tmp-scan-1-%04d.tif'`);
+  });
+
 });


### PR DESCRIPTION
The `scanimage --batcn=format` argument is unusual (for scanimage) in that it requires an `=` in it. The previous argument escaping does not play well, however. Without this change the resultant arguments end up looking like this:

```
scanimage -d deviceId .... '--batch=img%01d.jpg'
```

Which scanimage fails to parse well, which in turn causes scans to break.

This commit adds a special method for escaping argument pairs correctly.

Also adds unit test coverage.