### PR TITLE
Fix filters

### DIFF
--- a/app-server/src/classes/config.js
+++ b/app-server/src/classes/config.js
@@ -76,7 +76,7 @@ module.exports = class Config {
       filters: [
         {
           description: 'filter.auto-contrast',
-          params: '-auto-contrast'
+          params: '-equalize'
         },
         {
           description: 'filter.auto-level',
@@ -92,7 +92,7 @@ module.exports = class Config {
         },
         {
           description: 'filter.more-contrast',
-          params: '-level 90%,10%'
+          params: '+contrast +contrast +contrast'
         }
       ],
 


### PR DESCRIPTION
It seems that the filters added in #617 were not stable / reliable. This is most likely due to behavioural inconsistencies between imagemagick.

We need to work across versions going back years. That said, I couldn't see that they worked on any default version dating from buster to bookworm.