### PR TITLE
File list must include all files

### DIFF
--- a/app-server/src/api.js
+++ b/app-server/src/api.js
@@ -20,7 +20,6 @@ module.exports = new class Api {
     const dir = FileInfo.create(config.outputDirectory);
     let files = await dir.list();
     files = files
-      .filter(f => ['.tif', '.jpg', '.png', '.pdf', '.txt', '.zip'].includes(f.extension.toLowerCase()))
       .sort((f1, f2) => f2.lastModified - f1.lastModified);
     log.trace(LogFormatter.format().full(files));
     return files;


### PR DESCRIPTION
Closes #624

I have adopted the approach that a user may wish to rename the extension of the file and should be allowed to do so. As such I just removed the extension filter from the file list.

It does allow users to erroneously remove an extension, but they can change it back without shelling anywhere.

If this is unpopular, I may add a UI restriction, but I think this is sufficient to resolve the issue.