### PR TITLE
Enforce `xz` compression in `makedeb`

### DIFF
--- a/app-server/package.json
+++ b/app-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanservjs-server",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "scanservjs-api is a REST based API to control your scanner.",
   "scripts": {
     "build": "node build.js",

--- a/app-ui/package.json
+++ b/app-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanservjs-ui",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "scanservjs is a simple web-based UI for SANE which allows you to share a scanner on a network without the need for drivers or complicated installation.",
   "author": "Sam Strachan",
   "scripts": {

--- a/makedeb.sh
+++ b/makedeb.sh
@@ -232,7 +232,7 @@ chmod +x -v $DIR_DEBIAN/prerm
 chmod +x -v $DIR_LIB/server/server.js
 
 # Build
-dpkg-deb --root-owner-group --build ./debian ./debian/scanservjs_$VERSION-1_all.deb
+dpkg-deb --root-owner-group -Zxz --build ./debian ./debian/scanservjs_$VERSION-1_all.deb
 
 # Optional linting
 if [ "$1" = "--lint" ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scanservjs",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scanservjs",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "GPL-2.0",
       "workspaces": [
         "app-server",
@@ -19,7 +19,7 @@
     },
     "app-server": {
       "name": "scanservjs-server",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "GPL-2.0",
       "dependencies": {
         "adm-zip": "0.5.10",
@@ -42,7 +42,7 @@
     },
     "app-ui": {
       "name": "scanservjs-ui",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "GPL-2.0",
       "dependencies": {
         "@intlify/unplugin-vue-i18n": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanservjs",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "scanservjs is a simple web-based UI for SANE which allows you to share a scanner on a network without the need for drivers or complicated installation.",
   "scripts": {
     "build:version": "npm --allow-same-version --no-git-tag-version version $npm_package_version --workspaces",


### PR DESCRIPTION
So it turns out the GitHub builder runners are using ubuntu (which I knew) which defaults to newer default compression for `deb` files. Need to force the tested setting of `xz`