### PR TITLE
Adding multiple page options depending on scanner source

### DIFF
--- a/app-server/src/classes/request.js
+++ b/app-server/src/classes/request.js
@@ -71,6 +71,12 @@ module.exports = class Request {
     if ('--page-height' in features) {
       this.params.pageHeight = constrainWithFeature(data.params.pageHeight, features['--page-height']);
     }
+    if ('--page-height-ADF' in features) {
+      this.params.pageHeightADF = constrainWithFeature(data.params.pageHeightADF, features['--page-height-ADF']);
+    }
+    if ('--page-height-FB' in features) {
+      this.params.pageHeightFB = constrainWithFeature(data.params.pageHeightFB, features['--page-height-FB']);
+    }
     if ('--page-width' in features) {
       this.params.pageWidth = constrainWithFeature(data.params.pageWidth, features['--page-width']);
     }

--- a/app-server/src/classes/scanimage-command.js
+++ b/app-server/src/classes/scanimage-command.js
@@ -85,12 +85,22 @@ module.exports = class ScanimageCommand {
 
     cmdBuilder.arg('--resolution', params.resolution);
 
-    if ('pageWidth' in params) {
+    if ('pageWidth' in params && /ADF/.test(params.source)) {
+      cmdBuilder.arg('--page-width', params.pageWidthADF);
+    } else if ('pageWidth' in params && !/ADF/.test(params.source)) {
+      cmdBuilder.arg('--page-width', params.pageWidthFB);
+    } else if ('pageWidth' in params) {
       cmdBuilder.arg('--page-width', params.pageWidth);
     }
-    if ('pageHeight' in params) {
+
+    if ('pageHeightADF' in params && /ADF/.test(params.source)) {
+      cmdBuilder.arg('--page-height', params.pageHeightADF);
+    } else if ('pageHeightFB' in params && !/ADF/.test(params.source)) {
+      cmdBuilder.arg('--page-height', params.pageHeightFB);
+    } else if ('pageHeight' in params) {
       cmdBuilder.arg('--page-height', params.pageHeight);
     }
+    
     if ('left' in params) {
       cmdBuilder.arg('-l', params.left);
     }

--- a/app-ui/src/classes/request.js
+++ b/app-ui/src/classes/request.js
@@ -37,10 +37,15 @@ export default class Request {
     if ('--page-height' in device.features) {
       this.params.pageHeight = request.params.pageHeight || device.features['--page-height'].default;
     }
+    if ('--page-height-ADF' in device.features) {
+      this.params.pageHeightADF = request.params.pageHeightADF || device.features['--page-height-ADF'].default;
+    }
+    if ('--page-height-FB' in device.features) {
+      this.params.pageHeightFB = request.params.pageHeightFB || device.features['--page-height-FB'].default;
+    }
     if ('--page-width' in device.features) {
       this.params.pageWidth = request.params.pageWidth || device.features['--page-width'].default;
-    }
-    
+    }    
     if ('--adf-mode' in device.features) {
       this.params.adfMode = request.params.adfMode || device.features['--adf-mode'].default;
     }

--- a/docs/12-recipes.md
+++ b/docs/12-recipes.md
@@ -407,10 +407,9 @@ module.exports = {
 };
 ```
 
-The --page-height option will default to --page-height, if neither specific option is set.
-Even if the default option is set, it will try to use the the specific option first before falling back to the default. if you dont want to set the option for the flatbet for example you calso must not set the default option, as it will fall abck to this value instead.
+The --page-height option will default to --page-height if neither specific option is set. Even if the default option is set, it will try to use the specific option first before falling back to the default. If you don't want to set the option for the flatbed, for example, you must not set the default option, as it will fall back to this value instead.
 
-If the page height option should only be set for a ADF scan do this:
+If the page height option should only be set for an ADF scan, do this:
 
 ```javascript
 module.exports = {

--- a/docs/12-recipes.md
+++ b/docs/12-recipes.md
@@ -385,6 +385,48 @@ module.exports = {
 };
 ```
 
+## Different Page Height Variables for each source
+```javascript
+module.exports = {
+  afterConfig(config) {
+    devices.forEach(device => {
+      device.features['--page-height'] = {
+        default: 2720,
+        limits: [0, 2740]
+      };
+      device.features['--page-height-FB'] = {
+        default: 2730,
+        limits: [0, 2740]
+      };
+      device.features['--page-height-ADF'] = {
+        default: 2740,
+        limits: [0, 2740]
+      };
+    });
+  }
+};
+```
+
+The --page-height option will default to --page-height, if neither specific option is set.
+Even if the default option is set, it will try to use the the specific option first before falling back to the default. if you dont want to set the option for the flatbet for example you calso must not set the default option, as it will fall abck to this value instead.
+
+If the page height option should only be set for a ADF scan do this:
+
+```javascript
+module.exports = {
+  afterConfig(config) {
+    devices.forEach(device => {
+      device.features['--page-height-ADF'] = {
+        default: 2740,
+        limits: [0, 2740]
+      };
+    });
+  }
+};
+```
+
+The same also applies to --page-width*
+
 ## Other recipes?
 
 If you have other recipes then please share them.


### PR DESCRIPTION
**Description:** This pull request introduces a better solution than the workaround in #401. Instead of creating multiple "virtual" scanners to either set `--page-height` or not, this implementation allows different page height variables for each source.

An example is provided in `12-recipes.md`.

## Different Page Height Variables for Each Source

```javascript
module.exports = {
  afterConfig(config) {
    devices.forEach(device => {
      device.features['--page-height'] = {
        default: 2720,
        limits: [0, 2740]
      };
      device.features['--page-height-FB'] = {
        default: 2730,
        limits: [0, 2740]
      };
      device.features['--page-height-ADF'] = {
        default: 2740,
        limits: [0, 2740]
      };
    });
  }
};
```

The `--page-height` option will default to `--page-height` if neither specific option is set. Even if the default option is set, it will try to use the specific option first before falling back to the default. If you don't want to set the option for the flatbed, for example, you must not set the default option, as it will fall back to this value instead.

If the page height option should only be set for an ADF scan, use this configuration:

```javascript
module.exports = {
  afterConfig(config) {
    devices.forEach(device => {
      device.features['--page-height-ADF'] = {
        default: 2740,
        limits: [0, 2740]
      };
    });
  }
};
```

The drawback is that the user might have to set a few more variables, but it should not break any current config. The web scan works pretty flawlessly with the `device.features[].default` value. If someone wants to customize this value even further, they can provide the override values via the API.

Example: Assuming the above config with all the values set:

```json
"params": {
  "deviceId": "net:192.168.1.154:fujitsu:fi-7260:1226591",
  "resolution": 300,
  "width": 201,
  "height": 297,
  "left": 0,
  "top": 0,
  "pageHeightADF": 2000,
  "pageHeightFB": 1700,
  "pageHeight": 1000,
  "mode": "color",
  "source": "Flatbed",
  "brightness": 0,
  "contrast": 0
},
"filters": [],
"pipeline": "Paperless PDF",
"batch": "auto",
"index": 1
```

This would override the corresponding value in the SANE command with the new value provided in the API.

**Drawback:** If the value is not specified in the device features, it cannot be overridden. So in the second config example, a user with API usage intents could only override the `pageHeightADF` value, as it is the only one set. Even if they provided the new `pageHeightFB` value via the parameters, it should be different in my opinion.