### PR TITLE
feat: filter out directories from file list view

### DIFF
--- a/app-server/src/api.js
+++ b/app-server/src/api.js
@@ -20,6 +20,7 @@ module.exports = new class Api {
     const dir = FileInfo.create(config.outputDirectory);
     let files = await dir.list();
     files = files
+      .filter(file => !file.isDirectory)
       .sort((f1, f2) => f2.lastModified - f1.lastModified);
     log.trace(LogFormatter.format().full(files));
     return files;


### PR DESCRIPTION
Shared/network drives and system files (including hidden ones) appearing in the file list, the view can become cluttered and confusing. This simple fix filters out all directories to show only files.

Changes:
- Added filter to `fileList()` in **api.js** to exclude directories from results

TODO: Add configurable file type filters via UI dropdown/cfg

_Note: This is a non-breaking change_