### PR TITLE
Docker workflow: add labels and caching, push to GHCR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,12 +31,20 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
             ${{ secrets.DOCKERHUB_USERNAME }}/scanservjs
+            ghcr.io/${{ github.repository_owner }}/scanservjs
           tags: |
             type=schedule,pattern=staging
             type=semver,pattern={{raw}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,10 @@ on:
   release:
     types: [published]
 
+env:
+  BUILD_TARGET: scanservjs-core
+  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -27,31 +31,44 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/scanservjs
+          tags: |
+            type=schedule,pattern=staging
+            type=semver,pattern={{raw}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
       - name: New commit count
         run: echo "NEW_COMMIT_COUNT=$(git log --oneline --since '24 hours ago' | wc -l)" >> $GITHUB_ENV
- 
+
       - name: Push nightly staging
         if: github.ref == 'refs/heads/master' && env.NEW_COMMIT_COUNT > 0
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/scanservjs:staging
-          target: scanservjs-core
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-
-      - name: Get version
-        id: get_version
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          target: ${{ env.BUILD_TARGET }}
+          platforms: ${{ env.BUILD_PLATFORMS }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Push release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/build-push-action@v5
         with:
           push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/scanservjs:release-${{ steps.get_version.outputs.VERSION }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/scanservjs:${{ steps.get_version.outputs.VERSION }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/scanservjs:latest
-          target: scanservjs-core
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          target: ${{ env.BUILD_TARGET }}
+          platforms: ${{ env.BUILD_PLATFORMS }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
I've reworked the Docker workflow a little. I started just planning to add a push to GHCR, then the rest happened 😅 

* Add Docker image labels & annotations — This is useful for machine-readability (e.g. dependency management tools and more) and generally a good practice.
* Add push to GitHub Container Registry (GHCR) — This would be super nice to have, especially given that Docker Hub has recently even further decreased their pulls/hr allowance.
* Add additional image tags (e.g. an image for release `v3.0.4` would have tags `latest`, `v3.0.4`, `3.0.4`, `3.0`, `3`).
* Add caching via GitHub Actions cache — This should make image builds a lot faster.
* Some basic refactoring. More could be done to reduce to a single instance of `docker/build-push-action`, but I didn't want to make this too disruptive.

I ran some simple tests using [act](https://github.com/nektos/act) to see what the results of the `docker/metadata-action` would look like for each trigger.

The results look good as far as I'm concerned, however this does break the `workflow_dispatch` trigger insofar as no tags are generated for such events. As far as I can see this shouldn't be necessary, but I'm not sure specifically how, or even if you were using this trigger before, so let me know if this is a problem for you.

* `schedule`:
  ```json
  {
    "tags": [
      "tigattack/scanservjs:staging",
      "ghcr.io/tigattack/scanservjs:staging"
    ],
    "labels": {
      "org.opencontainers.image.created": "2025-03-12T16:16:54.031Z",
      "org.opencontainers.image.description": "SANE scanner nodejs web ui",
      "org.opencontainers.image.licenses": "GPL-2.0",
      "org.opencontainers.image.revision": "8d0588f6c5886ed3783853d06ece36b834c3d61f",
      "org.opencontainers.image.source": "https://github.com/tigattack/scanservjs",
      "org.opencontainers.image.title": "scanservjs",
      "org.opencontainers.image.url": "https://github.com/tigattack/scanservjs",
      "org.opencontainers.image.version": "staging"
    },
    "annotations": [
      "manifest:org.opencontainers.image.created=2025-03-12T16:16:54.031Z",
      "manifest:org.opencontainers.image.description=SANE scanner nodejs web ui",
      "manifest:org.opencontainers.image.licenses=GPL-2.0",
      "manifest:org.opencontainers.image.revision=8d0588f6c5886ed3783853d06ece36b834c3d61f",
      "manifest:org.opencontainers.image.source=https://github.com/tigattack/scanservjs",
      "manifest:org.opencontainers.image.title=scanservjs",
      "manifest:org.opencontainers.image.url=https://github.com/tigattack/scanservjs",
      "manifest:org.opencontainers.image.version=staging"
    ]
  }
  ```

* `release` trigger with mocked event data:
  ```json
  {
    "tags": [
      "tigattack/scanservjs:v3.0.4",
      "tigattack/scanservjs:3.0.4",
      "tigattack/scanservjs:3.0",
      "tigattack/scanservjs:3",
      "tigattack/scanservjs:latest",
      "ghcr.io/tigattack/scanservjs:v3.0.4",
      "ghcr.io/tigattack/scanservjs:3.0.4",
      "ghcr.io/tigattack/scanservjs:3.0",
      "ghcr.io/tigattack/scanservjs:3",
      "ghcr.io/tigattack/scanservjs:latest"
    ],
    "labels": {
      "org.opencontainers.image.created": "2025-03-12T16:16:21.098Z",
      "org.opencontainers.image.description": "SANE scanner nodejs web ui",
      "org.opencontainers.image.licenses": "GPL-2.0",
      "org.opencontainers.image.revision": "8d0588f6c5886ed3783853d06ece36b834c3d61f",
      "org.opencontainers.image.source": "https://github.com/tigattack/scanservjs",
      "org.opencontainers.image.title": "scanservjs",
      "org.opencontainers.image.url": "https://github.com/tigattack/scanservjs",
      "org.opencontainers.image.version": "v3.0.4"
    },
    "annotations": [
      "manifest:org.opencontainers.image.created=2025-03-12T16:16:21.098Z",
      "manifest:org.opencontainers.image.description=SANE scanner nodejs web ui",
      "manifest:org.opencontainers.image.licenses=GPL-2.0",
      "manifest:org.opencontainers.image.revision=8d0588f6c5886ed3783853d06ece36b834c3d61f",
      "manifest:org.opencontainers.image.source=https://github.com/tigattack/scanservjs",
      "manifest:org.opencontainers.image.title=scanservjs",
      "manifest:org.opencontainers.image.url=https://github.com/tigattack/scanservjs",
      "manifest:org.opencontainers.image.version=v3.0.4"
    ]
  }
  ```
  The event mock data looked like this:
  ```json
  {
    "action": "created",
    "release": {
      "tag_name": "v3.0.4"
    }
  }
  ```

* `workflow_dispatch`:
  ```json
  {
    "tags": [],
    "labels": {
      "org.opencontainers.image.created": "2025-03-12T16:24:36.661Z",
      "org.opencontainers.image.description": "SANE scanner nodejs web ui",
      "org.opencontainers.image.licenses": "GPL-2.0",
      "org.opencontainers.image.revision": "8d0588f6c5886ed3783853d06ece36b834c3d61f",
      "org.opencontainers.image.source": "https://github.com/tigattack/scanservjs",
      "org.opencontainers.image.title": "scanservjs",
      "org.opencontainers.image.url": "https://github.com/tigattack/scanservjs",
      "org.opencontainers.image.version": ""
    },
    "annotations": [
      "manifest:org.opencontainers.image.created=2025-03-12T16:24:36.661Z",
      "manifest:org.opencontainers.image.description=SANE scanner nodejs web ui",
      "manifest:org.opencontainers.image.licenses=GPL-2.0",
      "manifest:org.opencontainers.image.revision=8d0588f6c5886ed3783853d06ece36b834c3d61f",
      "manifest:org.opencontainers.image.source=https://github.com/tigattack/scanservjs",
      "manifest:org.opencontainers.image.title=scanservjs",
      "manifest:org.opencontainers.image.url=https://github.com/tigattack/scanservjs",
      "manifest:org.opencontainers.image.version="
    ]
  }
  ```