### PR TITLE
Security: Command Injection in CommandBuilder - Insufficient Input Validation

### DIFF
--- a/app-server/src/classes/command-builder.js
+++ b/app-server/src/classes/command-builder.js
@@ -18,8 +18,8 @@ module.exports = class CommandBuilder {
     if (['boolean', 'number'].includes(typeof value)) {
       return `${value}`;
     } else if ('string' === typeof value) {
-      if (value.includes('\'')) {
-        throw Error('Argument must not contain single quote "\'"');
+      if (value.includes('\'') || value.includes('`') || value.includes('$') || value.includes(';') || value.includes('|') || value.includes('&') || value.includes('<') || value.includes('>') || value.includes('(') || value.includes(')') || value.includes('\\') || value.includes('"')) {
+        throw Error('Argument contains forbidden characters');
       } else if (/^[0-9a-z-=/~.:]+$/i.test(value)) {
         return `${value}`;
       }


### PR DESCRIPTION
## Summary

Security: Command Injection in CommandBuilder - Insufficient Input Validation

## Problem

**Severity**: `High` | **File**: `app-server/src/classes/command-builder.js:L17`

The CommandBuilder class in app-server/src/classes/command-builder.js attempts to sanitize arguments but has gaps. The _format() method only allows alphanumeric, hyphen, equals, tilde, dot, colon, and forward slash characters without quotes. However, it doesn't properly handle all shell metacharacters. While single quotes are blocked, other dangerous characters like backticks, $(), and semicolons are allowed inside single-quoted strings in the test cases, but the validation regex `/^[0-9a-z-=/~.:]+$/i` is too permissive for unquoted arguments and could allow injection in certain contexts.

## Solution

Use a strict allowlist for unquoted arguments. For quoted arguments, ensure proper escaping. Consider using child_process.spawn with array arguments instead of shell command strings to avoid shell interpretation entirely. The current approach of building command strings is inherently risky.

## Changes

- `app-server/src/classes/command-builder.js` (modified)