### PR TITLE
feat(scan): add editable filename prefix

### DIFF
--- a/app-server/src/classes/config.js
+++ b/app-server/src/classes/config.js
@@ -41,8 +41,8 @@ module.exports = class Config {
           }
         }
       },
-      filename() {
-        return `scan_${dayjs().format('YYYY-MM-DD HH.mm.ss')}`;
+      filename(prefix) {
+        return `${prefix || 'scan_'}${dayjs().format('YYYY-MM-DD HH.mm.ss')}`;
       },
 
       scanimage: '/usr/bin/scanimage',

--- a/app-server/src/classes/request.js
+++ b/app-server/src/classes/request.js
@@ -11,6 +11,27 @@ function constrainWithFeature(value, feature) {
 }
 
 /**
+ * Sanitises a user supplied filename prefix so it is safe to use as (part of)
+ * a filename on disk. Strips path separators, control and reserved characters
+ * and leading dots, then trims and caps the length. Returns undefined when
+ * nothing usable remains, so the caller can fall back to the default.
+ * @param {*} value
+ * @returns {string|undefined}
+ */
+function sanitiseFilenamePrefix(value) {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const cleaned = value
+    // eslint-disable-next-line no-control-regex
+    .replace(/[/\\<>:"|?*\x00-\x1f\x7f]/g, '')
+    .replace(/^\.+/, '')
+    .trim()
+    .slice(0, 64);
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
+/**
  *
  * @param {string[]} list
  * @param {string|string[]} value
@@ -49,6 +70,7 @@ module.exports = class Request {
       filters: data.filters || device.settings.filters.default,
       pipeline: data.pipeline || device.settings.pipeline.default,
       batch: data.batch || device.settings.batchMode.default,
+      filenamePrefix: sanitiseFilenamePrefix(data.filenamePrefix),
       index: data.index || 1
     });
 

--- a/app-server/src/scan-controller.js
+++ b/app-server/src/scan-controller.js
@@ -103,7 +103,7 @@ class ScanController {
         .deflate(filenames.map(f => `${config.tempDirectory}/${f}`));
     }
 
-    const destination = `${config.outputDirectory}/${config.filename()}.${extension}`;
+    const destination = `${config.outputDirectory}/${config.filename(this.request.filenamePrefix)}.${extension}`;
     await FileInfo
       .create(`${config.tempDirectory}/${filename}`)
       .move(destination);

--- a/app-server/src/types.js
+++ b/app-server/src/types.js
@@ -104,6 +104,7 @@
  * @property {string[]} filters
  * @property {string} pipeline
  * @property {string} batch
+ * @property {string} [filenamePrefix]
  * @property {number} index
  */
 

--- a/app-server/test/request.test.js
+++ b/app-server/test/request.test.js
@@ -165,4 +165,29 @@ describe('Request', () => {
     assert.strictEqual(request.params.dynamicLineart, undefined);
   });
 
+  it('filenamePrefix', () => {
+    const file = FileInfo.create('test/resource/scanimage-a1.txt');
+    const device = Device.from(file.toText());
+    const context = new Context(config, [device], new UserOptions());
+    const base = {
+      params: { deviceId: 'plustek:libusb:001:008' },
+      pipeline: config.pipelines[0].description
+    };
+
+    const build = filenamePrefix =>
+      new Request(context, { ...base, filenamePrefix });
+
+    // A clean value passes through unchanged
+    assert.strictEqual(build('invoice_').filenamePrefix, 'invoice_');
+    // Missing / empty / whitespace-only falls back to undefined (=> default)
+    assert.strictEqual(build(undefined).filenamePrefix, undefined);
+    assert.strictEqual(build('').filenamePrefix, undefined);
+    assert.strictEqual(build('   ').filenamePrefix, undefined);
+    // Path separators, reserved chars and leading dots are stripped
+    assert.strictEqual(build('../../etc/passwd').filenamePrefix, 'etcpasswd');
+    assert.strictEqual(build('a/b\\c:d*e?').filenamePrefix, 'abcde');
+    // Non-string input is ignored
+    assert.strictEqual(build(42).filenamePrefix, undefined);
+  });
+
 });

--- a/app-ui/src/classes/request.js
+++ b/app-ui/src/classes/request.js
@@ -19,6 +19,7 @@ export default class Request {
       filters: request.filters || device.settings.filters.default,
       pipeline: request.pipeline || device.settings.pipeline.default,
       batch: request.batch || device.settings.batchMode.default,
+      filenamePrefix: request.filenamePrefix || '',
       index: 1
     });
 

--- a/app-ui/src/components/Scan.vue
+++ b/app-ui/src/components/Scan.vue
@@ -2,6 +2,12 @@
   <div>
     <v-row>
       <v-col cols="12" md="3" class="mb-10 mb-md-0">
+        <v-text-field
+          v-model="request.filenamePrefix"
+          :label="$t('scan.filename-prefix')"
+          placeholder="scan_"
+          persistent-placeholder />
+
         <div class="d-flex">
           <v-select v-if="context.devices.length > 0"
             v-model="device"

--- a/app-ui/src/locales/en.json
+++ b/app-ui/src/locales/en.json
@@ -159,6 +159,7 @@
     "batch": "Batch",
     "filters": "Filters",
     "format": "Format",
+    "filename-prefix": "Filename prefix",
     "btn-preview": "Preview",
     "btn-clear": "Clear",
     "btn-scan": "Scan",

--- a/app-ui/src/locales/fr.json
+++ b/app-ui/src/locales/fr.json
@@ -148,6 +148,7 @@
     "batch": "Assemblage",
     "filters": "Filtres",
     "format": "Format",
+    "filename-prefix": "Préfixe fichier",
     "btn-preview": "Aperçu",
     "btn-clear": "Effacer",
     "btn-scan": "Numériser",


### PR DESCRIPTION
Add a "Filename prefix" text field at the top of the left column in the scan view. It is passed through to the server, sanitised, and used as the prefix of the output filename (the timestamp is still appended to keep names unique). When left blank it falls back to the existing "scan_" default, so behaviour is unchanged for anyone who ignores the field.

- ui: new field bound to request.filenamePrefix, placeholder "scan_"
- ui: i18n keys scan.filename-prefix (en + fr)
- server: Request sanitises filenamePrefix (strips path separators, reserved/control chars and leading dots, caps length) so it is safe to use on disk; empty/invalid values fall back to the default
- server: config.filename(prefix) gains an optional prefix argument, backward compatible with a no-arg call
- test: cover prefix pass-through, fallback and sanitisation