### PR TITLE
docs(swagger): rename endpoint takes a JSON body, not text/plain

### DIFF
--- a/app-server/src/swagger.yml
+++ b/app-server/src/swagger.yml
@@ -109,9 +109,14 @@ paths:
         description: New filename
         required: true
         content:
-          text/plain:
+          application/json:
             schema:
-              type: string
+              type: object
+              required:
+                - newName
+              properties:
+                newName:
+                  type: string
       produces:
         - application/pdf
         - image/png


### PR DESCRIPTION
## What

The OpenAPI/Swagger spec documents the rename endpoint `PUT /api/v1/files/{filename}` as taking a `text/plain` string request body:

```yaml
requestBody:
  content:
    text/plain:
      schema:
        type: string
```

But the handler reads the new name from a JSON field — `const newName = req.body.newName;` (`app-server/src/express-configurer.js`). So a client that follows the documented `text/plain` contract sends a bare string, `req.body.newName` is `undefined`, and the file is renamed to `undefined` (per #816).

This documents the real contract: an `application/json` body with a required `newName` string property, matching the other JSON endpoints in the spec.

## Verification

Docs-only (`app-server/src/swagger.yml`). The YAML parses and the new `requestBody` is a valid OpenAPI 3.0 object schema consistent with the existing `application/json` request/response bodies in the file. No behavior change.

Closes #816.

---

Disclosure: prepared with AI assistance; I reviewed the change and verified the field name against the handler source cited above.
