### PR TITLE
Restore support for armv7 docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   BUILD_TARGET: scanservjs-core
-  BUILD_PLATFORMS: linux/amd64,linux/arm64
+  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
 jobs:
   docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # The builder image builds the core javascript app and debian package
 # ==============================================================================
-FROM node:24-trixie-slim AS scanservjs-build
+FROM --platform=$BUILDPLATFORM node:24-trixie-slim AS scanservjs-build
 ENV APP_DIR=/app
 WORKDIR "$APP_DIR"
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ complicated installation.
   [Help requested](https://github.com/sbs20/scanservjs/issues/154)
 * Light and dark mode
 * Responsive design
-* Docker images for `amd64` and `arm64`
+* Docker images for `amd64`, `arm64` and `armv7`
 * OpenAPI documentation
 
 It supports any


### PR DESCRIPTION
Closes #824

Restores the armv7 Docker image by running the Node 24 builder stage on the host's native architecture using `--platform=$BUILDPLATFORM`. Since the build output is architecture-independent, assets are compiled at native host speeds and safely packaged into the final armv7 Debian runtime.

Also updated the workflow build platforms and README.