### PR TITLE
Add Custom Actions on file row level, either as direct Icon Button or in an Overflow dropdown menu

### DIFF
--- a/app-server/config/config.default.js
+++ b/app-server/config/config.default.js
@@ -134,7 +134,22 @@ module.exports = {
   actions: [
     // {
     //   name: 'Echo',
-    //   async execute(fileInfo) {
+    //
+    //   // Optional. Icon to show in the UI - either one of the shorthand
+    //   // names the UI knows ('upload', 'cloud-upload', 'send', 'email',
+    //   // 'printer', 'share', 'run') or a raw SVG path (e.g. the value of any
+    //   // `@mdi/js` export).
+    //   icon: 'run',
+    //
+    //   // Optional, defaults to false. When true this action gets its own
+    //   // button on every file row. Otherwise it's listed in that row's
+    //   // overflow (⋮) menu. Either way it can also be applied to several
+    //   // files at once by selecting them and using the toolbar actions menu.
+    //   inline: true,
+    //
+    //   // `headers` holds the request headers of the UI click, and is only
+    //   // populated for actions run manually (not for `pipeline.afterAction`)
+    //   async execute(fileInfo, headers) {
     //     return await Process.spawn(`echo '${fileInfo.fullname}'`);
     //   }
     // }

--- a/app-server/src/classes/context.js
+++ b/app-server/src/classes/context.js
@@ -68,8 +68,14 @@ module.exports = class Context {
     /** @type {PaperSize[]} */
     this.paperSizes = config.paperSizes;
 
-    /** @type {string[]} */
-    this.actions = userOptions.actions().map(a => a.name);
+    /** @type {ActionInfo[]} */
+    this.actions = userOptions.actions().map(a => {
+      return {
+        name: a.name,
+        icon: a.icon,
+        inline: a.inline === true
+      };
+    });
   }
 
   /**

--- a/app-server/src/swagger.yml
+++ b/app-server/src/swagger.yml
@@ -464,7 +464,22 @@ definitions:
       actions:
         type: array
         items:
-          type: string
+          type: object
+          properties:
+            name:
+              type: string
+              example: "Echo"
+            icon:
+              type: string
+              description: >
+                Shorthand icon name known to the UI, or a raw SVG path.
+              example: "run"
+            inline:
+              type: boolean
+              description: >
+                Show as a dedicated button on each file row rather than in
+                that row's overflow menu.
+              default: false
 
   SystemInfoOs:
     properties:

--- a/app-server/src/types.js
+++ b/app-server/src/types.js
@@ -141,5 +141,20 @@
 /**
  * @typedef {Object} Action
  * @property {string} name
+ * @property {string} [icon] - Icon to show in the UI. Either one of the
+ * shorthand names the UI knows (e.g. 'upload', 'cloud-upload', 'send',
+ * 'email', 'printer', 'share', 'run') or a raw SVG path (e.g. the value of
+ * any `@mdi/js` export).
+ * @property {boolean} [inline] - When true the action gets its own button on
+ * every file row. Defaults to false, which lists it in that row's overflow
+ * menu instead.
  * @property {FnActionExec} execute
+ */
+
+/**
+ * The subset of an Action which is sent to the browser
+ * @typedef {Object} ActionInfo
+ * @property {string} name
+ * @property {string} [icon]
+ * @property {boolean} inline
  */

--- a/app-ui/src/components/Files.vue
+++ b/app-ui/src/components/Files.vue
@@ -67,6 +67,16 @@
       <v-icon class="mr-2" :icon="mdiDownload" @click="open(item)" />
       <v-icon class="mr-2" :icon="mdiPencil" @click="fileRename(item)" />
       <v-icon class="mr-2" :icon="mdiDelete" @click="fileRemove(item)" />
+      <v-menu v-if="actions.length > 0" bottom :offset-y="true">
+        <template #activator="{ props }">
+          <v-icon class="mr-2" :icon="mdiDotsVertical" v-bind="props" />
+        </template>
+        <v-list>
+          <v-list-item
+            v-for="(action, index) in actions" :key="index"
+            :title="action" @click="fileAction(action, item)" />
+        </v-list>
+      </v-menu>
     </template>
     <template #[`footer.page-text`]="items">
       {{ items.pageStart }} - {{ items.pageStop }} / {{ items.itemsLength }}
@@ -215,6 +225,19 @@ export default {
         this.$emit('notify', {type: 'e', message: error});
         this.$emit('mask', -1);
       });
+    },
+
+    async fileAction(actionName, file) {
+      this.$emit('mask', 1);
+      try {
+        await Common.fetch(`api/v1/files/${file.name}/actions/${actionName}`, {method: 'POST'});
+        this.$emit('notify', {type: 'i', message: `${this.$t('files.message:action', [actionName, file.name])}`});
+        this.fileList();
+      } catch (error) {
+        this.$emit('notify', {type: 'e', message: error});
+      } finally {
+        this.$emit('mask', -1);
+      }
     },
 
     fileRename(file) {

--- a/app-ui/src/components/Files.vue
+++ b/app-ui/src/components/Files.vue
@@ -29,7 +29,7 @@
           </template>
           <v-list>
             <v-list-item v-if="smAndDown" :title="$t('files.button:delete-selected')" @click="multipleDelete" />
-            <v-list-item v-for="(action, index) in actions" :key="index" :title="action" @click="multipleAction(action)" />
+            <v-list-item v-for="(action, index) in actions" :key="index" :title="action.name" @click="multipleAction(action.name)" />
           </v-list>
         </v-menu>
         <v-dialog v-model="dialogEdit" max-width="500px">
@@ -67,14 +67,18 @@
       <v-icon class="mr-2" :icon="mdiDownload" @click="open(item)" />
       <v-icon class="mr-2" :icon="mdiPencil" @click="fileRename(item)" />
       <v-icon class="mr-2" :icon="mdiDelete" @click="fileRemove(item)" />
-      <v-menu v-if="actions.length > 0" bottom :offset-y="true">
+      <v-icon
+        v-for="(action, index) in inlineActions" :key="index"
+        class="mr-2" :icon="actionIcon(action)" :title="action.name"
+        @click="fileAction(action.name, item)" />
+      <v-menu v-if="menuActions.length > 0" bottom :offset-y="true">
         <template #activator="{ props }">
           <v-icon class="mr-2" :icon="mdiDotsVertical" v-bind="props" />
         </template>
         <v-list>
           <v-list-item
-            v-for="(action, index) in actions" :key="index"
-            :title="action" @click="fileAction(action, item)" />
+            v-for="(action, index) in menuActions" :key="index"
+            :title="action.name" @click="fileAction(action.name, item)" />
         </v-list>
       </v-menu>
     </template>
@@ -87,9 +91,25 @@
 <script>
 import Common from '../classes/common';
 import Storage from '../classes/storage';
-import { mdiDelete, mdiDotsVertical, mdiDownload, mdiPencil } from '@mdi/js';
+import {
+  mdiCloudUpload, mdiDelete, mdiDotsVertical, mdiDownload, mdiEmail, mdiPencil,
+  mdiPlayCircleOutline, mdiPrinter, mdiSend, mdiShareVariant, mdiUpload
+} from '@mdi/js';
 import { useDisplay } from 'vuetify';
 const storage = Storage.instance();
+
+// Shorthand names an action may use for its `icon` in config.local.js. Any
+// other value is passed to v-icon as-is, so a raw SVG path (e.g. the value of
+// any @mdi/js export) works too.
+const ACTION_ICONS = {
+  'cloud-upload': mdiCloudUpload,
+  email: mdiEmail,
+  printer: mdiPrinter,
+  run: mdiPlayCircleOutline,
+  send: mdiSend,
+  share: mdiShareVariant,
+  upload: mdiUpload
+};
 
 export default {
   name: 'Files',
@@ -130,6 +150,14 @@ export default {
   },
 
   computed: {
+    inlineActions() {
+      return this.actions.filter(a => a.inline);
+    },
+
+    menuActions() {
+      return this.actions.filter(a => !a.inline);
+    },
+
     headers() {
       const headers = [
         {
@@ -191,6 +219,10 @@ export default {
   },
 
   methods: {
+    actionIcon(action) {
+      return ACTION_ICONS[action.icon] || action.icon || mdiPlayCircleOutline;
+    },
+
     actionList() {
       this.$emit('mask', 1);
       Common.fetch('api/v1/context').then(context => {


### PR DESCRIPTION
**Disclaimer**: 
This is fully implemented by Claude.
I minimally tested this on my own and it works for me.
Let me know if you want any changes/checks done, and I can try to think myself through it if its not too much, but honestly it works and I can keep running it exactly as this.
But I fully understand you denying this, just based on the above.

**About this**
I want to upload my documents directly to paperless after scanning, but the selection part is overkill, I need it on the row.
So added was:
Configuration on the actions to mark it as an additional icon (incl. icon definition) on each row at the end, otherwise they are in an overflow three dots icon, providing a drop down menu to selection the action.
